### PR TITLE
align question font size with design and fix bug

### DIFF
--- a/src/components/Question.tsx
+++ b/src/components/Question.tsx
@@ -13,7 +13,7 @@ const StyledQuestion = styled.div`
 
 &.openstax-question {
   border-top: 1px solid ${colors.palette.pale};
-  font-size: 2rem;
+  font-size: 1.8rem;
 
   .detailed-solution {
     margin-bottom: 1rem;
@@ -42,8 +42,8 @@ const StyledQuestion = styled.div`
 
   .answers-table {
     margin-bottom: 20px;
-    font-size: 17px;
-    line-height: 25px;
+    font-size: 1.6rem;
+    line-height: 2rem;
   }
 
   .instructions {

--- a/src/components/__snapshots__/Exercise.spec.tsx.snap
+++ b/src/components/__snapshots__/Exercise.spec.tsx.snap
@@ -69,7 +69,7 @@ exports[`Exercise using step data matches snapshot 1`] = `
         data-test-id="student-exercise-question"
       >
         <div
-          className="sc-jSMfEi dlMRRl openstax-question step-card-body"
+          className="sc-jSMfEi cJTgkj openstax-question step-card-body"
           data-question-number={1}
           data-test-id="question"
         >
@@ -279,7 +279,7 @@ exports[`Exercise with question state data matches snapshot 1`] = `
         data-test-id="student-exercise-question"
       >
         <div
-          className="sc-jSMfEi dlMRRl openstax-question step-card-body"
+          className="sc-jSMfEi cJTgkj openstax-question step-card-body"
           data-question-number={1}
           data-test-id="question"
         >
@@ -489,7 +489,7 @@ exports[`Exercise with question state data shows a detailed solution 1`] = `
         data-test-id="student-exercise-question"
       >
         <div
-          className="sc-jSMfEi dlMRRl openstax-question step-card-body"
+          className="sc-jSMfEi cJTgkj openstax-question step-card-body"
           data-question-number={1}
           data-test-id="question"
         >

--- a/src/components/__snapshots__/ExerciseQuestion.spec.tsx.snap
+++ b/src/components/__snapshots__/ExerciseQuestion.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`ExerciseQuestion matches snapshot 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi cNELgS openstax-question step-card-body"
+    className="sc-gsnTZi BkYSI openstax-question step-card-body"
     data-question-number={1}
     data-test-id="question"
   >
@@ -158,7 +158,7 @@ exports[`ExerciseQuestion renders Re-submit button 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi cNELgS openstax-question step-card-body has-incorrect-answer"
+    className="sc-gsnTZi BkYSI openstax-question step-card-body has-incorrect-answer"
     data-question-number={1}
     data-test-id="question"
   >
@@ -312,7 +312,7 @@ exports[`ExerciseQuestion renders Save button 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi cNELgS openstax-question step-card-body has-incorrect-answer"
+    className="sc-gsnTZi BkYSI openstax-question step-card-body has-incorrect-answer"
     data-question-number={1}
     data-test-id="question"
   >
@@ -466,7 +466,7 @@ exports[`ExerciseQuestion renders all attempts remaining 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi cNELgS openstax-question step-card-body"
+    className="sc-gsnTZi BkYSI openstax-question step-card-body"
     data-question-number={1}
     data-test-id="question"
   >
@@ -626,7 +626,7 @@ exports[`ExerciseQuestion renders continue button (unused?) 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi cNELgS openstax-question step-card-body has-incorrect-answer"
+    className="sc-gsnTZi BkYSI openstax-question step-card-body has-incorrect-answer"
     data-question-number={1}
     data-test-id="question"
   >
@@ -779,7 +779,7 @@ exports[`ExerciseQuestion renders detailed solution and published comments 1`] =
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi cNELgS openstax-question step-card-body has-correct-answer has-incorrect-answer"
+    className="sc-gsnTZi BkYSI openstax-question step-card-body has-correct-answer has-incorrect-answer"
     data-question-number={1}
     data-test-id="question"
   >
@@ -933,7 +933,7 @@ exports[`ExerciseQuestion renders free response 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi cNELgS openstax-question step-card-body"
+    className="sc-gsnTZi BkYSI openstax-question step-card-body"
     data-question-number={1}
     data-test-id="question"
   >
@@ -1091,7 +1091,7 @@ exports[`ExerciseQuestion renders no attempts remaining 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi cNELgS openstax-question step-card-body has-incorrect-answer"
+    className="sc-gsnTZi BkYSI openstax-question step-card-body has-incorrect-answer"
     data-question-number={1}
     data-test-id="question"
   >
@@ -1244,7 +1244,7 @@ exports[`ExerciseQuestion renders some attempts remaining 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi cNELgS openstax-question step-card-body has-incorrect-answer"
+    className="sc-gsnTZi BkYSI openstax-question step-card-body has-incorrect-answer"
     data-question-number={1}
     data-test-id="question"
   >

--- a/src/components/__snapshots__/Question.spec.tsx.snap
+++ b/src/components/__snapshots__/Question.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Question defaults QuestionHtml html 1`] = `
 <div
-  className="sc-bczRLJ JeQfc openstax-question"
+  className="sc-bczRLJ blQdma openstax-question"
   data-question-number={1}
   data-test-id="question"
 >
@@ -120,7 +120,7 @@ exports[`Question defaults QuestionHtml html 1`] = `
 
 exports[`Question defaults collaborator_solutions 1`] = `
 <div
-  className="sc-bczRLJ JeQfc openstax-question"
+  className="sc-bczRLJ blQdma openstax-question"
   data-question-number={1}
   data-test-id="question"
 >
@@ -238,7 +238,7 @@ exports[`Question defaults collaborator_solutions 1`] = `
 
 exports[`Question defaults formats 1`] = `
 <div
-  className="sc-bczRLJ JeQfc openstax-question"
+  className="sc-bczRLJ blQdma openstax-question"
   data-question-number={1}
   data-test-id="question"
 >
@@ -365,7 +365,7 @@ exports[`Question defaults formats 1`] = `
 
 exports[`Question matches snapshot 1`] = `
 <div
-  className="sc-bczRLJ JeQfc openstax-question"
+  className="sc-bczRLJ blQdma openstax-question"
   data-question-number={1}
   data-test-id="question"
 >
@@ -483,7 +483,7 @@ exports[`Question matches snapshot 1`] = `
 
 exports[`Question renders exercise uid 1`] = `
 <div
-  className="sc-bczRLJ JeQfc openstax-question"
+  className="sc-bczRLJ blQdma openstax-question"
   data-question-number={1}
   data-test-id="question"
 >
@@ -606,7 +606,7 @@ exports[`Question renders exercise uid 1`] = `
 
 exports[`Question renders formats 1`] = `
 <div
-  className="sc-bczRLJ JeQfc openstax-question"
+  className="sc-bczRLJ blQdma openstax-question"
   data-question-number={1}
   data-test-id="question"
 >
@@ -736,7 +736,7 @@ exports[`Question renders formats 1`] = `
 
 exports[`Question renders solutions 1`] = `
 <div
-  className="sc-bczRLJ JeQfc openstax-question"
+  className="sc-bczRLJ blQdma openstax-question"
   data-question-number={1}
   data-test-id="question"
 >

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -196,7 +196,7 @@ export const mixins = {
         flex-direction: column;
         &::after {
           ${mixins.answerCorrectText()}
-          width: $openstax-answer-bubble-size !important;
+          width: ${layouts.answer.bubbleSize} !important;
           margin-left: 0;
         }
       }


### PR DESCRIPTION
If we decide to pull Question into Tutor we will need to override to the original values there, but this should begin aligning some of the font/sizing differences with the designs. Holding off on nav and bubble size changes for now.