### PR TITLE
Next button

### DIFF
--- a/src/components/Exercise.spec.tsx
+++ b/src/components/Exercise.spec.tsx
@@ -6,7 +6,7 @@ describe('Exercise', () => {
 
     let props: ExerciseWithStepDataProps;
 
-    beforeEach(() => {
+    beforeEach(() => {  
       props = {
         exercise: {
           uid: '1@1',
@@ -68,7 +68,6 @@ describe('Exercise', () => {
           incorrectAnswerId: 0
         },
         numberOfQuestions: 1,
-        scrollToQuestion: 1,
       }
     });
 
@@ -78,19 +77,6 @@ describe('Exercise', () => {
       ).toJSON();
       expect(tree).toMatchSnapshot();
     });
-
-    it('scrolls to question', () => {
-      const spyScroll = jest.spyOn(window, 'scrollTo');
-
-      renderer.create(
-        <Exercise {...props} />
-      );
-  
-      /* eslint-disable-next-line @typescript-eslint/no-empty-function */
-      renderer.act(() => {});
-      expect(spyScroll).toHaveBeenCalledTimes(1);
-    })
-  });
 
   describe('with question state data', () => {
     let props: ExerciseWithQuestionStatesProps;

--- a/src/components/Exercise.spec.tsx
+++ b/src/components/Exercise.spec.tsx
@@ -67,7 +67,8 @@ describe('Exercise', () => {
           attempt_number: 1,
           incorrectAnswerId: 0
         },
-        numberOfQuestions: 1
+        numberOfQuestions: 1,
+        scrollToQuestion: 1,
       }
     });
 
@@ -77,6 +78,18 @@ describe('Exercise', () => {
       ).toJSON();
       expect(tree).toMatchSnapshot();
     });
+
+    it('scrolls to question', () => {
+      const spyScroll = jest.spyOn(window, 'scrollTo');
+
+      renderer.create(
+        <Exercise {...props} />
+      );
+  
+      /* eslint-disable-next-line @typescript-eslint/no-empty-function */
+      renderer.act(() => {});
+      expect(spyScroll).toHaveBeenCalledTimes(1);
+    })
   });
 
   describe('with question state data', () => {

--- a/src/components/Exercise.spec.tsx
+++ b/src/components/Exercise.spec.tsx
@@ -1,5 +1,6 @@
 import { Exercise, ExerciseWithStepDataProps, ExerciseWithQuestionStatesProps } from './Exercise';
 import renderer from 'react-test-renderer';
+import React from 'react';
 
 describe('Exercise', () => {
   describe('using step data', () => {
@@ -83,6 +84,12 @@ describe('Exercise', () => {
     let props: ExerciseWithQuestionStatesProps;
 
     beforeEach(() => {
+      const ref = { current: null };
+      Object.defineProperty(ref, 'current', {
+        get: jest.fn(() => [null, 'element'])
+      });
+      jest.spyOn(React, "useRef").mockReturnValue(ref);
+
       props = {
         exercise: {
           uid: '1@1',
@@ -120,6 +127,7 @@ describe('Exercise', () => {
         },
         questionNumber: 1,
         numberOfQuestions: 1,
+        scrollToQuestion: 1,
         hasMultipleAttempts: false,
         onAnswerChange: () => null,
         onAnswerSave: () => null,
@@ -154,6 +162,7 @@ describe('Exercise', () => {
       const tree = renderer.create(
         <Exercise {...props} />
       );
+      renderer.act(() => {});
       expect(tree.toJSON()).toMatchSnapshot();
       expect(tree.root.findByProps({ "data-test-id": "continue-btn" }).props['children']).toContain('Next');
     });

--- a/src/components/Exercise.spec.tsx
+++ b/src/components/Exercise.spec.tsx
@@ -162,7 +162,6 @@ describe('Exercise', () => {
       const tree = renderer.create(
         <Exercise {...props} />
       );
-      renderer.act(() => {});
       expect(tree.toJSON()).toMatchSnapshot();
       expect(tree.root.findByProps({ "data-test-id": "continue-btn" }).props['children']).toContain('Next');
     });

--- a/src/components/Exercise.spec.tsx
+++ b/src/components/Exercise.spec.tsx
@@ -77,6 +77,7 @@ describe('Exercise', () => {
       ).toJSON();
       expect(tree).toMatchSnapshot();
     });
+  });
 
   describe('with question state data', () => {
     let props: ExerciseWithQuestionStatesProps;

--- a/src/components/Exercise.spec.tsx
+++ b/src/components/Exercise.spec.tsx
@@ -6,7 +6,7 @@ describe('Exercise', () => {
 
     let props: ExerciseWithStepDataProps;
 
-    beforeEach(() => {  
+    beforeEach(() => {
       props = {
         exercise: {
           uid: '1@1',
@@ -67,7 +67,7 @@ describe('Exercise', () => {
           attempt_number: 1,
           incorrectAnswerId: 0
         },
-        numberOfQuestions: 1,
+        numberOfQuestions: 1
       }
     });
 

--- a/src/components/Exercise.tsx
+++ b/src/components/Exercise.tsx
@@ -61,6 +61,7 @@ export const Exercise = ({
   React.useEffect(() => {
     const el = scrollToQuestion && questionsRef.current[scrollToQuestion];
     if (el) {
+      console.log('element: ', el, scrollToQuestion)
       scrollToElement(el);
     }
   }, [scrollToQuestion, exercise]);
@@ -78,7 +79,7 @@ export const Exercise = ({
         <ExerciseQuestion
           {...props}
           {...state}
-          ref={(el: HTMLDivElement) => questionsRef.current[questionNumber] = el}
+          ref={(el: HTMLDivElement) => questionsRef.current[questionNumber + 1] = el}
           exercise_uid={exercise.uid}
           key={q.id}
           question={q}

--- a/src/components/Exercise.tsx
+++ b/src/components/Exercise.tsx
@@ -56,11 +56,6 @@ export const Exercise = ({
   numberOfQuestions, questionNumber, step, exercise, show_all_feedback, scrollToQuestion, ...props
 }: ExerciseWithStepDataProps | ExerciseWithQuestionStatesProps) => {
   const legacyStepRender = 'feedback_html' in step;
-  
-
-  const handleScroll = () => {
-    //
-  }
 
   React.useEffect(() => {
     if (typeof document === 'undefined') {
@@ -71,18 +66,6 @@ export const Exercise = ({
       scrollToElement(el);
     }
   }, [scrollToQuestion, exercise]);
-
-  React.useEffect(() => {
-    if (typeof document === 'undefined' || exercise.questions.length >= 1) {
-      return;
-    }
-    document.addEventListener('scroll', handleScroll);
-    handleScroll();
-
-    return () => {
-      document?.removeEventListener('scroll', handleScroll);
-    };
-  }, []);
 
   return (<StyledTaskStepCard
     step={step}

--- a/src/components/Exercise.tsx
+++ b/src/components/Exercise.tsx
@@ -61,7 +61,6 @@ export const Exercise = ({
   React.useEffect(() => {
     const el = scrollToQuestion && questionsRef.current[scrollToQuestion];
     if (el) {
-      console.log('element: ', el, scrollToQuestion)
       scrollToElement(el);
     }
   }, [scrollToQuestion, exercise]);

--- a/src/components/Exercise.tsx
+++ b/src/components/Exercise.tsx
@@ -33,7 +33,7 @@ export interface ExerciseBaseProps {
   answer_id_order?: ID[];
   hasMultipleAttempts: boolean;
   onAnswerSave: (question_id: number) => void;
-  onNextStep: (i: number) => void;
+  onNextStep: (currentQuestionNumber: number) => void;
   show_all_feedback?: boolean;
   scrollToQuestion?: number;
 }
@@ -56,12 +56,10 @@ export const Exercise = ({
   numberOfQuestions, questionNumber, step, exercise, show_all_feedback, scrollToQuestion, ...props
 }: ExerciseWithStepDataProps | ExerciseWithQuestionStatesProps) => {
   const legacyStepRender = 'feedback_html' in step;
+  const questionsRef = React.useRef<Array<HTMLDivElement>>([]);
 
   React.useEffect(() => {
-    if (typeof document === 'undefined') {
-      return;
-    }
-    const el = document.querySelector(`.openstax-question[data-question-number="${scrollToQuestion}"]`)
+    const el = scrollToQuestion && questionsRef.current[scrollToQuestion];
     if (el) {
       scrollToElement(el);
     }
@@ -80,6 +78,7 @@ export const Exercise = ({
         <ExerciseQuestion
           {...props}
           {...state}
+          ref={(el: HTMLDivElement) => questionsRef.current[questionNumber] = el}
           exercise_uid={exercise.uid}
           key={q.id}
           question={q}

--- a/src/components/Exercise.tsx
+++ b/src/components/Exercise.tsx
@@ -33,7 +33,7 @@ export interface ExerciseBaseProps {
   answer_id_order?: ID[];
   hasMultipleAttempts: boolean;
   onAnswerSave: (question_id: number) => void;
-  onNextStep: () => void;
+  onNextStep: (i: number) => void;
   show_all_feedback?: boolean;
   scrollToQuestion?: number;
 }
@@ -56,13 +56,33 @@ export const Exercise = ({
   numberOfQuestions, questionNumber, step, exercise, show_all_feedback, scrollToQuestion, ...props
 }: ExerciseWithStepDataProps | ExerciseWithQuestionStatesProps) => {
   const legacyStepRender = 'feedback_html' in step;
+  
+
+  const handleScroll = () => {
+    //
+  }
 
   React.useEffect(() => {
+    if (typeof document === 'undefined') {
+      return;
+    }
     const el = document.querySelector(`.openstax-question[data-question-number="${scrollToQuestion}"]`)
     if (el) {
       scrollToElement(el);
     }
   }, [scrollToQuestion, exercise]);
+
+  React.useEffect(() => {
+    if (typeof document === 'undefined' || exercise.questions.length >= 1) {
+      return;
+    }
+    document.addEventListener('scroll', handleScroll);
+    handleScroll();
+
+    return () => {
+      document?.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
 
   return (<StyledTaskStepCard
     step={step}

--- a/src/components/ExerciseQuestion.spec.tsx
+++ b/src/components/ExerciseQuestion.spec.tsx
@@ -1,4 +1,4 @@
-import { ExerciseQuestion, ExerciseQuestionProps, SaveButton } from './ExerciseQuestion';
+import { ExerciseQuestion, ExerciseQuestionProps, SaveButton, NextButton } from './ExerciseQuestion';
 import renderer from 'react-test-renderer';
 
 describe('ExerciseQuestion', () => {
@@ -171,6 +171,24 @@ describe('ExerciseQuestion', () => {
     );
     renderer.act(() => {
       tree.root.findByType(SaveButton).props.onClick();
+    });
+
+    expect(mockFn).toHaveBeenCalledWith(1);
+  });
+
+  it('passes question number on next button click', () => {
+    const mockFn = jest.fn();
+
+    const tree = renderer.create(
+      <ExerciseQuestion
+        {...props}
+        needsSaved={false}
+        canAnswer={true}
+        onNextStep={mockFn}
+      />
+    );
+    renderer.act(() => {
+      tree.root.findByType(NextButton).props.onClick();
     });
 
     expect(mockFn).toHaveBeenCalledWith(1);

--- a/src/components/ExerciseQuestion.tsx
+++ b/src/components/ExerciseQuestion.tsx
@@ -86,7 +86,7 @@ const FreeResponseReview = ({ free_response }: Pick<ExerciseQuestionProps, "free
   );
 }
 
-export const ExerciseQuestion = React.forwardRef((props: ExerciseQuestionProps, ref) => {
+export const ExerciseQuestion = React.forwardRef((props: ExerciseQuestionProps, ref: React.ForwardedRef<HTMLDivElement>) => {
   const {
     question, task, answer_id_order, onAnswerChange, feedback_html, correct_answer_feedback_html,
     is_completed, correct_answer_id, incorrectAnswerId, choicesEnabled, questionNumber,

--- a/src/components/ExerciseQuestion.tsx
+++ b/src/components/ExerciseQuestion.tsx
@@ -15,7 +15,7 @@ export interface ExerciseQuestionProps {
   hasMultipleAttempts: boolean;
   onAnswerChange: () => void;
   onAnswerSave: ExerciseBaseProps['onAnswerSave'];
-  onNextStep: () => void;
+  onNextStep: ExerciseBaseProps['onNextStep'];
   feedback_html: string;
   correct_answer_feedback_html: string;
   is_completed: boolean;
@@ -68,10 +68,11 @@ export const SaveButton = (props: {
 
 const NextButton = (props: {
   canUpdateCurrentStep: boolean,
-  onNextStep: ExerciseQuestionProps['onNextStep']
+  onNextStep: ExerciseQuestionProps['onNextStep'],
+  currentQuestionNumber: number,
 }) => {
   return (
-    <Button onClick={props.onNextStep} data-test-id="continue-btn">
+    <Button onClick={props.onNextStep(currentQuestionNumber)} data-test-id="continue-btn">
       {props.canUpdateCurrentStep ? 'Continue' : 'Next'}
     </Button>
   );
@@ -137,7 +138,7 @@ export const ExerciseQuestion = (props: ExerciseQuestionProps) => {
                 attempt_number={attempt_number}
                 onClick={() => onAnswerSave(numberfyId(question.id))}
               /> :
-              <NextButton onNextStep={onNextStep} canUpdateCurrentStep={canUpdateCurrentStep} />}
+              <NextButton onNextStep={onNextStep} currentQuestionNumber={questionNumber} canUpdateCurrentStep={canUpdateCurrentStep} />}
           </div>
         </div>
       </StepCardFooter>

--- a/src/components/ExerciseQuestion.tsx
+++ b/src/components/ExerciseQuestion.tsx
@@ -68,11 +68,9 @@ export const SaveButton = (props: {
 
 const NextButton = (props: {
   canUpdateCurrentStep: boolean,
-  onNextStep: ExerciseQuestionProps['onNextStep'],
-  currentQuestionNumber: number,
-}) => {
+} & React.ComponentPropsWithoutRef<'button'>) => {
   return (
-    <Button onClick={props.onNextStep(currentQuestionNumber)} data-test-id="continue-btn">
+    <Button data-test-id="continue-btn">
       {props.canUpdateCurrentStep ? 'Continue' : 'Next'}
     </Button>
   );
@@ -138,7 +136,7 @@ export const ExerciseQuestion = (props: ExerciseQuestionProps) => {
                 attempt_number={attempt_number}
                 onClick={() => onAnswerSave(numberfyId(question.id))}
               /> :
-              <NextButton onNextStep={onNextStep} currentQuestionNumber={questionNumber} canUpdateCurrentStep={canUpdateCurrentStep} />}
+              <NextButton onClick={() => onNextStep(questionNumber)} canUpdateCurrentStep={canUpdateCurrentStep} />}
           </div>
         </div>
       </StepCardFooter>

--- a/src/components/ExerciseQuestion.tsx
+++ b/src/components/ExerciseQuestion.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { numberfyId } from "../../src/utils";
 import { AvailablePoints, ID, ExerciseQuestionData, Task } from "../types";
 import Button from "./Button";
@@ -66,11 +67,11 @@ export const SaveButton = (props: {
   </Button>
 );
 
-const NextButton = (props: {
+export const NextButton = (props: {
   canUpdateCurrentStep: boolean,
 } & React.ComponentPropsWithoutRef<'button'>) => {
   return (
-    <Button data-test-id="continue-btn">
+    <Button {...props} data-test-id="continue-btn">
       {props.canUpdateCurrentStep ? 'Continue' : 'Next'}
     </Button>
   );
@@ -85,7 +86,7 @@ const FreeResponseReview = ({ free_response }: Pick<ExerciseQuestionProps, "free
   );
 }
 
-export const ExerciseQuestion = (props: ExerciseQuestionProps) => {
+export const ExerciseQuestion = React.forwardRef((props: ExerciseQuestionProps, ref) => {
   const {
     question, task, answer_id_order, onAnswerChange, feedback_html, correct_answer_feedback_html,
     is_completed, correct_answer_id, incorrectAnswerId, choicesEnabled, questionNumber,
@@ -97,6 +98,7 @@ export const ExerciseQuestion = (props: ExerciseQuestionProps) => {
   return (
     <div data-test-id="student-exercise-question">
       <Question
+        ref={ref}
         task={task}
         question={question}
         answerIdOrder={answer_id_order}
@@ -142,4 +144,4 @@ export const ExerciseQuestion = (props: ExerciseQuestionProps) => {
       </StepCardFooter>
     </div>
   );
-}
+})

--- a/src/components/Question.tsx
+++ b/src/components/Question.tsx
@@ -3,7 +3,7 @@ import { mixins, colors, layouts, transitions } from '../theme';
 import { AnswersTable } from './AnswersTable';
 import classnames from 'classnames';
 import { ID, ExerciseQuestionData, Task } from 'src/types';
-import { ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 import { Content } from './Content';
 
 const StyledQuestion = styled.div`
@@ -253,7 +253,7 @@ export interface QuestionProps {
   choicesEnabled?: boolean;
 }
 
-export const Question = (props: QuestionProps) => {
+export const Question = React.forwardRef((props: QuestionProps, ref) => {
   let exerciseUid, solution;
 
   const {
@@ -306,7 +306,7 @@ export const Question = (props: QuestionProps) => {
   }
 
   return (
-    <StyledQuestion className={classes} data-question-number={questionNumber} data-test-id="question">
+    <StyledQuestion ref={ref as React.RefObject<HTMLDivElement>} className={classes} data-question-number={questionNumber} data-test-id="question">
       <QuestionHtml type="context" html={context} hidden={hidePreambles} />
       <QuestionHtml type="stimulus" html={stimulus_html} hidden={hidePreambles} />
       <QuestionHtml type="stem" html={stem_html} hidden={hidePreambles} questionNumber={questionNumber} />
@@ -322,7 +322,7 @@ export const Question = (props: QuestionProps) => {
       {exerciseUid}
     </StyledQuestion>
   );
-}
+});
 
 interface QuestionHtmlProps {
   html?: string;

--- a/src/components/Question.tsx
+++ b/src/components/Question.tsx
@@ -255,7 +255,7 @@ export interface QuestionProps {
   choicesEnabled?: boolean;
 }
 
-export const Question = React.forwardRef((props: QuestionProps, ref) => {
+export const Question = React.forwardRef((props: QuestionProps, ref: React.ForwardedRef<HTMLDivElement>) => {
   let exerciseUid, solution;
 
   const {
@@ -308,7 +308,7 @@ export const Question = React.forwardRef((props: QuestionProps, ref) => {
   }
 
   return (
-    <StyledQuestion ref={ref as React.RefObject<HTMLDivElement>} className={classes} data-question-number={questionNumber} data-test-id="question">
+    <StyledQuestion ref={ref} className={classes} data-question-number={questionNumber} data-test-id="question">
       <QuestionHtml type="context" html={context} hidden={hidePreambles} />
       <QuestionHtml type="stimulus" html={stimulus_html} hidden={hidePreambles} />
       <QuestionHtml type="stem" html={stem_html} hidden={hidePreambles} questionNumber={questionNumber} />


### PR DESCRIPTION
Drafting this in case I'm not in on Monday. Two things happening here:
- I'm passing the current `questionNumber` to the `onNextStep` callback so we can detect if someone has moved between questions in a multipart
- I replace querySelector with refs when looking for the question to scroll to. This seemed like the React way to do it but very open to feedback - not sure if the ref.current as array thing is janky