### PR TITLE
Fix more things

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -18,7 +18,6 @@ export const InnerStepCard = styled.div`
 
   ${breakpoints.desktop`
     max-width: 1000px;
-    min-width: 750px;
   `}
 `;
 

--- a/src/components/Exercise.spec.tsx
+++ b/src/components/Exercise.spec.tsx
@@ -74,7 +74,7 @@ describe('Exercise', () => {
 
     it('matches snapshot', () => {
       const tree = renderer.create(
-        <Exercise {...props} />
+        <Exercise {...props} show_all_feedback />
       ).toJSON();
       expect(tree).toMatchSnapshot();
     });

--- a/src/components/Exercise.stories.tsx
+++ b/src/components/Exercise.stories.tsx
@@ -65,7 +65,7 @@ const exerciseWithStepDataProps: ExerciseWithStepDataProps = {
   canUpdateCurrentStep: false
 }
 
-const exerciseWithQuestionStatesProps: ExerciseWithQuestionStatesProps = {
+const exerciseWithQuestionStatesProps = (): ExerciseWithQuestionStatesProps => { return {
   exercise: {
     uid: '1@1',
     uuid: 'e4e27897-4abc-40d3-8565-5def31795edc',
@@ -129,16 +129,17 @@ const exerciseWithQuestionStatesProps: ExerciseWithQuestionStatesProps = {
       apiIsPending: false
     }
   },
-};
+}};
 
 export const Default = () => {
   const [selectedAnswerId, setSelectedAnswerId] = useState<number>(0);
   const [apiIsPending, setApiIsPending] = useState(false)
-  exerciseWithQuestionStatesProps.questionStates['1'].answer_id = selectedAnswerId;
-  exerciseWithQuestionStatesProps.questionStates['1'].apiIsPending = apiIsPending;
+  const props = exerciseWithQuestionStatesProps();
+  props.questionStates['1'].answer_id = selectedAnswerId;
+  props.questionStates['1'].apiIsPending = apiIsPending;
   return (
     <Exercise
-      {...exerciseWithQuestionStatesProps}
+      {...props}
       onAnswerChange={(a: Omit<Answer, 'id'> & { id: number, question_id: number }) => {
         setSelectedAnswerId(a.id)
       }}
@@ -150,7 +151,7 @@ export const DeprecatedStepData = () => <Exercise {...exerciseWithStepDataProps}
 
 export const CompleteWithFeedback = () => {
   const props: ExerciseWithQuestionStatesProps = {
-    ...exerciseWithQuestionStatesProps,
+    ...exerciseWithQuestionStatesProps(),
 
     questionStates: {
       '1': {
@@ -176,7 +177,7 @@ export const CompleteWithFeedback = () => {
 };
 
 export const IncorrectWithFeedbackAndSolution = () => {
-  const props: ExerciseWithQuestionStatesProps = { ...exerciseWithQuestionStatesProps };
+  const props: ExerciseWithQuestionStatesProps = { ...exerciseWithQuestionStatesProps() };
   props.questionStates = {
     '1': {
       available_points: '1.0',
@@ -200,7 +201,7 @@ export const IncorrectWithFeedbackAndSolution = () => {
 };
 
 export const IncorrectWithFeedbackAndSolutionWrappingText = () => {
-  const props: ExerciseWithQuestionStatesProps = { ...exerciseWithQuestionStatesProps };
+  const props: ExerciseWithQuestionStatesProps = exerciseWithQuestionStatesProps();
   props.questionStates = {
     '1': {
       available_points: '1.0',
@@ -329,7 +330,7 @@ export const MultiPartHalfComplete = () => {
 
 export const Icons = () => {
   return <Exercise
-    {...exerciseWithQuestionStatesProps}
+    {...exerciseWithQuestionStatesProps()}
     showExerciseIcons={true}
     topicUrl='https://openstax.org'
     errataUrl='https://openstax.org'

--- a/src/components/Exercise.stories.tsx
+++ b/src/components/Exercise.stories.tsx
@@ -199,6 +199,32 @@ export const IncorrectWithFeedbackAndSolution = () => {
   return <Exercise {...props} />;
 };
 
+export const IncorrectWithFeedbackAndSolutionWrappingText = () => {
+  const props: ExerciseWithQuestionStatesProps = { ...exerciseWithQuestionStatesProps };
+  props.questionStates = {
+    '1': {
+      available_points: '1.0',
+      is_completed: true,
+      answer_id_order: ['1', '2'],
+      answer_id: 2,
+      free_response: 'Free response',
+      feedback_html: 'Feedback for the incorrect answer',
+      correct_answer_id: '1',
+      correct_answer_feedback_html: 'Feedback for the correct answer',
+      attempts_remaining: 0,
+      attempt_number: 1,
+      incorrectAnswerId: '2',
+      solution: { content_html: 'A detailed solution', solution_type: 'detailed' },
+      canAnswer: true,
+      needsSaved: false,
+      apiIsPending: false
+    }
+  };
+  props.exercise.questions[0].answers[0].content_html = 'A very long correct answer to observe line wrapping at mobile sizes';
+  props.exercise.questions[0].answers[1].content_html = 'A very long incorrect answer to observe line wrapping at mobile sizes';
+  return <Exercise {...props} />;
+};
+
 export const MultiPartHalfComplete = () => {
   const props: ExerciseWithQuestionStatesProps = {
     exercise: {

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -18,6 +18,7 @@ const Wrapper = styled.div`
   align-items: center;
   > svg {
     max-width: 600px;
+    flex-grow: 1;
   }
 `;
 

--- a/src/components/Question.tsx
+++ b/src/components/Question.tsx
@@ -97,15 +97,19 @@ const StyledQuestion = styled.div`
       }
     }
 
+    .answers-answer.answer-correct .answer-answer {
+      align-items: flex-start;
+      margin-top: calc((${layouts.answer.bubbleSize} / 2) - 1rem);
+    }
+
     .answer-letter {
       text-align: center;
       padding: 0;
-      font-size: 1.4rem;
+      font-size: 1.6rem;
       display: flex;
       justify-content: center;
       align-items: center;
     }
-
 
     .answer-label {
       font-weight: normal;

--- a/src/components/__snapshots__/Card.spec.tsx.snap
+++ b/src/components/__snapshots__/Card.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`StepCard matches snapshot 1`] = `
   className="sc-gsnTZi kTXtGE"
 >
   <div
-    className="sc-bczRLJ hctMxl"
+    className="sc-bczRLJ YKyJl"
   >
     <div
       className="sc-dkzDqf jPnAkk"
@@ -52,7 +52,7 @@ exports[`StepCard matches snapshot with more than one question 1`] = `
   className="sc-gsnTZi kTXtGE"
 >
   <div
-    className="sc-bczRLJ hctMxl"
+    className="sc-bczRLJ YKyJl"
   >
     <div
       className="sc-dkzDqf jPnAkk"
@@ -106,7 +106,7 @@ exports[`TaskStepCard can optionally provide task 1`] = `
   data-task-step-id={1}
 >
   <div
-    className="sc-bczRLJ hctMxl exercise-step"
+    className="sc-bczRLJ YKyJl exercise-step"
   >
     <div
       className="sc-dkzDqf jPnAkk"
@@ -153,7 +153,7 @@ exports[`TaskStepCard can optionally provide type 1`] = `
   data-task-step-id={1}
 >
   <div
-    className="sc-bczRLJ hctMxl exercise-step"
+    className="sc-bczRLJ YKyJl exercise-step"
   >
     <div
       className="sc-dkzDqf jPnAkk"
@@ -200,7 +200,7 @@ exports[`TaskStepCard matches snapshot 1`] = `
   data-task-step-id={1}
 >
   <div
-    className="sc-bczRLJ hctMxl exercise-step"
+    className="sc-bczRLJ YKyJl exercise-step"
   >
     <div
       className="sc-dkzDqf jPnAkk"

--- a/src/components/__snapshots__/Exercise.spec.tsx.snap
+++ b/src/components/__snapshots__/Exercise.spec.tsx.snap
@@ -6,7 +6,7 @@ exports[`Exercise using step data matches snapshot 1`] = `
   data-task-step-id={1}
 >
   <div
-    className="sc-bczRLJ hctMxl exercise-step sc-iqcoie cbfqin"
+    className="sc-bczRLJ YKyJl exercise-step sc-iqcoie cbfqin"
   >
     <div
       className="sc-dkzDqf jPnAkk"
@@ -216,7 +216,7 @@ exports[`Exercise with question state data matches snapshot 1`] = `
   data-task-step-id={1}
 >
   <div
-    className="sc-bczRLJ hctMxl exercise-step sc-iqcoie cbfqin"
+    className="sc-bczRLJ YKyJl exercise-step sc-iqcoie cbfqin"
   >
     <div
       className="sc-dkzDqf jPnAkk"
@@ -420,7 +420,7 @@ exports[`Exercise with question state data renders header icons with multiple ch
   data-task-step-id={1}
 >
   <div
-    className="sc-bczRLJ hctMxl exercise-step sc-iqcoie cbfqin"
+    className="sc-bczRLJ YKyJl exercise-step sc-iqcoie cbfqin"
   >
     <div
       className="sc-dkzDqf jPnAkk"
@@ -745,7 +745,7 @@ exports[`Exercise with question state data renders header icons with two-step ex
   data-task-step-id={1}
 >
   <div
-    className="sc-bczRLJ hctMxl exercise-step sc-iqcoie cbfqin"
+    className="sc-bczRLJ YKyJl exercise-step sc-iqcoie cbfqin"
   >
     <div
       className="sc-dkzDqf jPnAkk"
@@ -1030,7 +1030,7 @@ exports[`Exercise with question state data shows a detailed solution 1`] = `
   data-task-step-id={1}
 >
   <div
-    className="sc-bczRLJ hctMxl exercise-step sc-iqcoie cbfqin"
+    className="sc-bczRLJ YKyJl exercise-step sc-iqcoie cbfqin"
   >
     <div
       className="sc-dkzDqf jPnAkk"

--- a/src/components/__snapshots__/Exercise.spec.tsx.snap
+++ b/src/components/__snapshots__/Exercise.spec.tsx.snap
@@ -69,7 +69,7 @@ exports[`Exercise using step data matches snapshot 1`] = `
         data-test-id="student-exercise-question"
       >
         <div
-          className="sc-jqUVSM ghJTot openstax-question step-card-body"
+          className="sc-jqUVSM dcgwRc openstax-question step-card-body"
           data-question-number={1}
           data-test-id="question"
         >
@@ -273,7 +273,7 @@ exports[`Exercise with question state data matches snapshot 1`] = `
         data-test-id="student-exercise-question"
       >
         <div
-          className="sc-jqUVSM ghJTot openstax-question step-card-body"
+          className="sc-jqUVSM dcgwRc openstax-question step-card-body"
           data-question-number={1}
           data-test-id="question"
         >
@@ -598,7 +598,7 @@ exports[`Exercise with question state data renders header icons with multiple ch
         data-test-id="student-exercise-question"
       >
         <div
-          className="sc-jqUVSM ghJTot openstax-question step-card-body"
+          className="sc-jqUVSM dcgwRc openstax-question step-card-body"
           data-question-number={1}
           data-test-id="question"
         >
@@ -883,7 +883,7 @@ exports[`Exercise with question state data renders header icons with two-step ex
         data-test-id="student-exercise-question"
       >
         <div
-          className="sc-jqUVSM ghJTot openstax-question step-card-body"
+          className="sc-jqUVSM dcgwRc openstax-question step-card-body"
           data-question-number={1}
           data-test-id="question"
         >
@@ -1087,7 +1087,7 @@ exports[`Exercise with question state data shows a detailed solution 1`] = `
         data-test-id="student-exercise-question"
       >
         <div
-          className="sc-jqUVSM ghJTot openstax-question step-card-body"
+          className="sc-jqUVSM dcgwRc openstax-question step-card-body"
           data-question-number={1}
           data-test-id="question"
         >

--- a/src/components/__snapshots__/Exercise.spec.tsx.snap
+++ b/src/components/__snapshots__/Exercise.spec.tsx.snap
@@ -69,7 +69,7 @@ exports[`Exercise using step data matches snapshot 1`] = `
         data-test-id="student-exercise-question"
       >
         <div
-          className="sc-jqUVSM dcgwRc openstax-question step-card-body"
+          className="sc-jqUVSM ghJTot openstax-question step-card-body"
           data-question-number={1}
           data-test-id="question"
         >
@@ -273,7 +273,7 @@ exports[`Exercise with question state data matches snapshot 1`] = `
         data-test-id="student-exercise-question"
       >
         <div
-          className="sc-jqUVSM dcgwRc openstax-question step-card-body"
+          className="sc-jqUVSM ghJTot openstax-question step-card-body"
           data-question-number={1}
           data-test-id="question"
         >
@@ -598,7 +598,7 @@ exports[`Exercise with question state data renders header icons with multiple ch
         data-test-id="student-exercise-question"
       >
         <div
-          className="sc-jqUVSM dcgwRc openstax-question step-card-body"
+          className="sc-jqUVSM ghJTot openstax-question step-card-body"
           data-question-number={1}
           data-test-id="question"
         >
@@ -883,7 +883,7 @@ exports[`Exercise with question state data renders header icons with two-step ex
         data-test-id="student-exercise-question"
       >
         <div
-          className="sc-jqUVSM dcgwRc openstax-question step-card-body"
+          className="sc-jqUVSM ghJTot openstax-question step-card-body"
           data-question-number={1}
           data-test-id="question"
         >
@@ -1087,7 +1087,7 @@ exports[`Exercise with question state data shows a detailed solution 1`] = `
         data-test-id="student-exercise-question"
       >
         <div
-          className="sc-jqUVSM dcgwRc openstax-question step-card-body"
+          className="sc-jqUVSM ghJTot openstax-question step-card-body"
           data-question-number={1}
           data-test-id="question"
         >

--- a/src/components/__snapshots__/Exercise.spec.tsx.snap
+++ b/src/components/__snapshots__/Exercise.spec.tsx.snap
@@ -69,7 +69,7 @@ exports[`Exercise using step data matches snapshot 1`] = `
         data-test-id="student-exercise-question"
       >
         <div
-          className="sc-jqUVSM kpZOzU openstax-question step-card-body"
+          className="sc-jqUVSM ghJTot openstax-question step-card-body"
           data-question-number={1}
           data-test-id="question"
         >
@@ -273,7 +273,7 @@ exports[`Exercise with question state data matches snapshot 1`] = `
         data-test-id="student-exercise-question"
       >
         <div
-          className="sc-jqUVSM kpZOzU openstax-question step-card-body"
+          className="sc-jqUVSM ghJTot openstax-question step-card-body"
           data-question-number={1}
           data-test-id="question"
         >
@@ -481,7 +481,7 @@ exports[`Exercise with question state data renders header icons with multiple ch
                 />
               </svg>
               <div
-                className="sc-gKXOVf fuUtVw popover right"
+                className="sc-gKXOVf fcYMUq popover right"
               >
                 <div
                   className="arrow"
@@ -520,7 +520,7 @@ exports[`Exercise with question state data renders header icons with multiple ch
                 />
               </svg>
               <div
-                className="sc-gKXOVf fuUtVw popover right"
+                className="sc-gKXOVf fcYMUq popover right"
               >
                 <div
                   className="arrow"
@@ -559,7 +559,7 @@ exports[`Exercise with question state data renders header icons with multiple ch
                 />
               </svg>
               <div
-                className="sc-gKXOVf fuUtVw popover right"
+                className="sc-gKXOVf fcYMUq popover right"
               >
                 <div
                   className="arrow"
@@ -598,7 +598,7 @@ exports[`Exercise with question state data renders header icons with multiple ch
         data-test-id="student-exercise-question"
       >
         <div
-          className="sc-jqUVSM kpZOzU openstax-question step-card-body"
+          className="sc-jqUVSM ghJTot openstax-question step-card-body"
           data-question-number={1}
           data-test-id="question"
         >
@@ -805,7 +805,7 @@ exports[`Exercise with question state data renders header icons with two-step ex
                 />
               </svg>
               <div
-                className="sc-gKXOVf fuUtVw popover right"
+                className="sc-gKXOVf fcYMUq popover right"
               >
                 <div
                   className="arrow"
@@ -844,7 +844,7 @@ exports[`Exercise with question state data renders header icons with two-step ex
                 />
               </svg>
               <div
-                className="sc-gKXOVf fuUtVw popover right"
+                className="sc-gKXOVf fcYMUq popover right"
               >
                 <div
                   className="arrow"
@@ -883,7 +883,7 @@ exports[`Exercise with question state data renders header icons with two-step ex
         data-test-id="student-exercise-question"
       >
         <div
-          className="sc-jqUVSM kpZOzU openstax-question step-card-body"
+          className="sc-jqUVSM ghJTot openstax-question step-card-body"
           data-question-number={1}
           data-test-id="question"
         >
@@ -1087,7 +1087,7 @@ exports[`Exercise with question state data shows a detailed solution 1`] = `
         data-test-id="student-exercise-question"
       >
         <div
-          className="sc-jqUVSM kpZOzU openstax-question step-card-body"
+          className="sc-jqUVSM ghJTot openstax-question step-card-body"
           data-question-number={1}
           data-test-id="question"
         >

--- a/src/components/__snapshots__/ExerciseIcons.spec.tsx.snap
+++ b/src/components/__snapshots__/ExerciseIcons.spec.tsx.snap
@@ -30,7 +30,7 @@ exports[`ExerciseIcons matches snapshot 1`] = `
         />
       </svg>
       <div
-        className="sc-dkzDqf kKHNLl popover right"
+        className="sc-dkzDqf crCAWf popover right"
       >
         <div
           className="arrow"
@@ -69,7 +69,7 @@ exports[`ExerciseIcons matches snapshot 1`] = `
         />
       </svg>
       <div
-        className="sc-dkzDqf kKHNLl popover right"
+        className="sc-dkzDqf crCAWf popover right"
       >
         <div
           className="arrow"
@@ -108,7 +108,7 @@ exports[`ExerciseIcons matches snapshot 1`] = `
         />
       </svg>
       <div
-        className="sc-dkzDqf kKHNLl popover right"
+        className="sc-dkzDqf crCAWf popover right"
       >
         <div
           className="arrow"

--- a/src/components/__snapshots__/ExerciseQuestion.spec.tsx.snap
+++ b/src/components/__snapshots__/ExerciseQuestion.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`ExerciseQuestion matches snapshot 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi gTmcAX openstax-question step-card-body"
+    className="sc-gsnTZi kkcBIO openstax-question step-card-body"
     data-question-number={1}
     data-test-id="question"
   >
@@ -158,7 +158,7 @@ exports[`ExerciseQuestion renders Re-submit button 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi gTmcAX openstax-question step-card-body has-incorrect-answer"
+    className="sc-gsnTZi kkcBIO openstax-question step-card-body has-incorrect-answer"
     data-question-number={1}
     data-test-id="question"
   >
@@ -312,7 +312,7 @@ exports[`ExerciseQuestion renders Save button 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi gTmcAX openstax-question step-card-body has-incorrect-answer"
+    className="sc-gsnTZi kkcBIO openstax-question step-card-body has-incorrect-answer"
     data-question-number={1}
     data-test-id="question"
   >
@@ -466,7 +466,7 @@ exports[`ExerciseQuestion renders all attempts remaining 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi gTmcAX openstax-question step-card-body"
+    className="sc-gsnTZi kkcBIO openstax-question step-card-body"
     data-question-number={1}
     data-test-id="question"
   >
@@ -626,7 +626,7 @@ exports[`ExerciseQuestion renders continue button (unused?) 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi gTmcAX openstax-question step-card-body has-incorrect-answer"
+    className="sc-gsnTZi kkcBIO openstax-question step-card-body has-incorrect-answer"
     data-question-number={1}
     data-test-id="question"
   >
@@ -779,7 +779,7 @@ exports[`ExerciseQuestion renders detailed solution and published comments 1`] =
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi gTmcAX openstax-question step-card-body has-correct-answer has-incorrect-answer"
+    className="sc-gsnTZi kkcBIO openstax-question step-card-body has-correct-answer has-incorrect-answer"
     data-question-number={1}
     data-test-id="question"
   >
@@ -933,7 +933,7 @@ exports[`ExerciseQuestion renders free response 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi gTmcAX openstax-question step-card-body"
+    className="sc-gsnTZi kkcBIO openstax-question step-card-body"
     data-question-number={1}
     data-test-id="question"
   >
@@ -1091,7 +1091,7 @@ exports[`ExerciseQuestion renders no attempts remaining 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi gTmcAX openstax-question step-card-body has-incorrect-answer"
+    className="sc-gsnTZi kkcBIO openstax-question step-card-body has-incorrect-answer"
     data-question-number={1}
     data-test-id="question"
   >
@@ -1244,7 +1244,7 @@ exports[`ExerciseQuestion renders some attempts remaining 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi gTmcAX openstax-question step-card-body has-incorrect-answer"
+    className="sc-gsnTZi kkcBIO openstax-question step-card-body has-incorrect-answer"
     data-question-number={1}
     data-test-id="question"
   >

--- a/src/components/__snapshots__/ExerciseQuestion.spec.tsx.snap
+++ b/src/components/__snapshots__/ExerciseQuestion.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`ExerciseQuestion matches snapshot 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi hwcDSL openstax-question step-card-body"
+    className="sc-gsnTZi kkcBIO openstax-question step-card-body"
     data-question-number={1}
     data-test-id="question"
   >
@@ -158,7 +158,7 @@ exports[`ExerciseQuestion renders Re-submit button 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi hwcDSL openstax-question step-card-body has-incorrect-answer"
+    className="sc-gsnTZi kkcBIO openstax-question step-card-body has-incorrect-answer"
     data-question-number={1}
     data-test-id="question"
   >
@@ -312,7 +312,7 @@ exports[`ExerciseQuestion renders Save button 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi hwcDSL openstax-question step-card-body has-incorrect-answer"
+    className="sc-gsnTZi kkcBIO openstax-question step-card-body has-incorrect-answer"
     data-question-number={1}
     data-test-id="question"
   >
@@ -466,7 +466,7 @@ exports[`ExerciseQuestion renders all attempts remaining 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi hwcDSL openstax-question step-card-body"
+    className="sc-gsnTZi kkcBIO openstax-question step-card-body"
     data-question-number={1}
     data-test-id="question"
   >
@@ -626,7 +626,7 @@ exports[`ExerciseQuestion renders continue button (unused?) 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi hwcDSL openstax-question step-card-body has-incorrect-answer"
+    className="sc-gsnTZi kkcBIO openstax-question step-card-body has-incorrect-answer"
     data-question-number={1}
     data-test-id="question"
   >
@@ -779,7 +779,7 @@ exports[`ExerciseQuestion renders detailed solution and published comments 1`] =
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi hwcDSL openstax-question step-card-body has-correct-answer has-incorrect-answer"
+    className="sc-gsnTZi kkcBIO openstax-question step-card-body has-correct-answer has-incorrect-answer"
     data-question-number={1}
     data-test-id="question"
   >
@@ -933,7 +933,7 @@ exports[`ExerciseQuestion renders free response 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi hwcDSL openstax-question step-card-body"
+    className="sc-gsnTZi kkcBIO openstax-question step-card-body"
     data-question-number={1}
     data-test-id="question"
   >
@@ -1091,7 +1091,7 @@ exports[`ExerciseQuestion renders no attempts remaining 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi hwcDSL openstax-question step-card-body has-incorrect-answer"
+    className="sc-gsnTZi kkcBIO openstax-question step-card-body has-incorrect-answer"
     data-question-number={1}
     data-test-id="question"
   >
@@ -1244,7 +1244,7 @@ exports[`ExerciseQuestion renders some attempts remaining 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi hwcDSL openstax-question step-card-body has-incorrect-answer"
+    className="sc-gsnTZi kkcBIO openstax-question step-card-body has-incorrect-answer"
     data-question-number={1}
     data-test-id="question"
   >

--- a/src/components/__snapshots__/ExerciseQuestion.spec.tsx.snap
+++ b/src/components/__snapshots__/ExerciseQuestion.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`ExerciseQuestion matches snapshot 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi kkcBIO openstax-question step-card-body"
+    className="sc-gsnTZi hwcDSL openstax-question step-card-body"
     data-question-number={1}
     data-test-id="question"
   >
@@ -158,7 +158,7 @@ exports[`ExerciseQuestion renders Re-submit button 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi kkcBIO openstax-question step-card-body has-incorrect-answer"
+    className="sc-gsnTZi hwcDSL openstax-question step-card-body has-incorrect-answer"
     data-question-number={1}
     data-test-id="question"
   >
@@ -312,7 +312,7 @@ exports[`ExerciseQuestion renders Save button 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi kkcBIO openstax-question step-card-body has-incorrect-answer"
+    className="sc-gsnTZi hwcDSL openstax-question step-card-body has-incorrect-answer"
     data-question-number={1}
     data-test-id="question"
   >
@@ -466,7 +466,7 @@ exports[`ExerciseQuestion renders all attempts remaining 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi kkcBIO openstax-question step-card-body"
+    className="sc-gsnTZi hwcDSL openstax-question step-card-body"
     data-question-number={1}
     data-test-id="question"
   >
@@ -626,7 +626,7 @@ exports[`ExerciseQuestion renders continue button (unused?) 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi kkcBIO openstax-question step-card-body has-incorrect-answer"
+    className="sc-gsnTZi hwcDSL openstax-question step-card-body has-incorrect-answer"
     data-question-number={1}
     data-test-id="question"
   >
@@ -779,7 +779,7 @@ exports[`ExerciseQuestion renders detailed solution and published comments 1`] =
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi kkcBIO openstax-question step-card-body has-correct-answer has-incorrect-answer"
+    className="sc-gsnTZi hwcDSL openstax-question step-card-body has-correct-answer has-incorrect-answer"
     data-question-number={1}
     data-test-id="question"
   >
@@ -933,7 +933,7 @@ exports[`ExerciseQuestion renders free response 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi kkcBIO openstax-question step-card-body"
+    className="sc-gsnTZi hwcDSL openstax-question step-card-body"
     data-question-number={1}
     data-test-id="question"
   >
@@ -1091,7 +1091,7 @@ exports[`ExerciseQuestion renders no attempts remaining 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi kkcBIO openstax-question step-card-body has-incorrect-answer"
+    className="sc-gsnTZi hwcDSL openstax-question step-card-body has-incorrect-answer"
     data-question-number={1}
     data-test-id="question"
   >
@@ -1244,7 +1244,7 @@ exports[`ExerciseQuestion renders some attempts remaining 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-gsnTZi kkcBIO openstax-question step-card-body has-incorrect-answer"
+    className="sc-gsnTZi hwcDSL openstax-question step-card-body has-incorrect-answer"
     data-question-number={1}
     data-test-id="question"
   >

--- a/src/components/__snapshots__/Loader.spec.tsx.snap
+++ b/src/components/__snapshots__/Loader.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Loader matches snapshot 1`] = `
 <div
-  className="sc-bczRLJ dHoDgd"
+  className="sc-bczRLJ hXcEew"
 >
   <svg
     aria-labelledby="OSLoader-aria"

--- a/src/components/__snapshots__/Question.spec.tsx.snap
+++ b/src/components/__snapshots__/Question.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Question defaults QuestionHtml html 1`] = `
 <div
-  className="sc-bczRLJ ePSJdR openstax-question"
+  className="sc-bczRLJ jqMCQk openstax-question"
   data-question-number={1}
   data-test-id="question"
 >
@@ -120,7 +120,7 @@ exports[`Question defaults QuestionHtml html 1`] = `
 
 exports[`Question defaults collaborator_solutions 1`] = `
 <div
-  className="sc-bczRLJ ePSJdR openstax-question"
+  className="sc-bczRLJ jqMCQk openstax-question"
   data-question-number={1}
   data-test-id="question"
 >
@@ -238,7 +238,7 @@ exports[`Question defaults collaborator_solutions 1`] = `
 
 exports[`Question defaults formats 1`] = `
 <div
-  className="sc-bczRLJ ePSJdR openstax-question"
+  className="sc-bczRLJ jqMCQk openstax-question"
   data-question-number={1}
   data-test-id="question"
 >
@@ -365,7 +365,7 @@ exports[`Question defaults formats 1`] = `
 
 exports[`Question matches snapshot 1`] = `
 <div
-  className="sc-bczRLJ ePSJdR openstax-question"
+  className="sc-bczRLJ jqMCQk openstax-question"
   data-question-number={1}
   data-test-id="question"
 >
@@ -483,7 +483,7 @@ exports[`Question matches snapshot 1`] = `
 
 exports[`Question renders exercise uid 1`] = `
 <div
-  className="sc-bczRLJ ePSJdR openstax-question"
+  className="sc-bczRLJ jqMCQk openstax-question"
   data-question-number={1}
   data-test-id="question"
 >
@@ -606,7 +606,7 @@ exports[`Question renders exercise uid 1`] = `
 
 exports[`Question renders formats 1`] = `
 <div
-  className="sc-bczRLJ ePSJdR openstax-question"
+  className="sc-bczRLJ jqMCQk openstax-question"
   data-question-number={1}
   data-test-id="question"
 >
@@ -736,7 +736,7 @@ exports[`Question renders formats 1`] = `
 
 exports[`Question renders solutions 1`] = `
 <div
-  className="sc-bczRLJ ePSJdR openstax-question"
+  className="sc-bczRLJ jqMCQk openstax-question"
   data-question-number={1}
   data-test-id="question"
 >

--- a/src/components/__snapshots__/Question.spec.tsx.snap
+++ b/src/components/__snapshots__/Question.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Question defaults QuestionHtml html 1`] = `
 <div
-  className="sc-bczRLJ jqMCQk openstax-question"
+  className="sc-bczRLJ ePSJdR openstax-question"
   data-question-number={1}
   data-test-id="question"
 >
@@ -120,7 +120,7 @@ exports[`Question defaults QuestionHtml html 1`] = `
 
 exports[`Question defaults collaborator_solutions 1`] = `
 <div
-  className="sc-bczRLJ jqMCQk openstax-question"
+  className="sc-bczRLJ ePSJdR openstax-question"
   data-question-number={1}
   data-test-id="question"
 >
@@ -238,7 +238,7 @@ exports[`Question defaults collaborator_solutions 1`] = `
 
 exports[`Question defaults formats 1`] = `
 <div
-  className="sc-bczRLJ jqMCQk openstax-question"
+  className="sc-bczRLJ ePSJdR openstax-question"
   data-question-number={1}
   data-test-id="question"
 >
@@ -365,7 +365,7 @@ exports[`Question defaults formats 1`] = `
 
 exports[`Question matches snapshot 1`] = `
 <div
-  className="sc-bczRLJ jqMCQk openstax-question"
+  className="sc-bczRLJ ePSJdR openstax-question"
   data-question-number={1}
   data-test-id="question"
 >
@@ -483,7 +483,7 @@ exports[`Question matches snapshot 1`] = `
 
 exports[`Question renders exercise uid 1`] = `
 <div
-  className="sc-bczRLJ jqMCQk openstax-question"
+  className="sc-bczRLJ ePSJdR openstax-question"
   data-question-number={1}
   data-test-id="question"
 >
@@ -606,7 +606,7 @@ exports[`Question renders exercise uid 1`] = `
 
 exports[`Question renders formats 1`] = `
 <div
-  className="sc-bczRLJ jqMCQk openstax-question"
+  className="sc-bczRLJ ePSJdR openstax-question"
   data-question-number={1}
   data-test-id="question"
 >
@@ -736,7 +736,7 @@ exports[`Question renders formats 1`] = `
 
 exports[`Question renders solutions 1`] = `
 <div
-  className="sc-bczRLJ jqMCQk openstax-question"
+  className="sc-bczRLJ ePSJdR openstax-question"
   data-question-number={1}
   data-test-id="question"
 >

--- a/src/components/__snapshots__/Question.spec.tsx.snap
+++ b/src/components/__snapshots__/Question.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Question defaults QuestionHtml html 1`] = `
 <div
-  className="sc-bczRLJ logtpp openstax-question"
+  className="sc-bczRLJ jqMCQk openstax-question"
   data-question-number={1}
   data-test-id="question"
 >
@@ -120,7 +120,7 @@ exports[`Question defaults QuestionHtml html 1`] = `
 
 exports[`Question defaults collaborator_solutions 1`] = `
 <div
-  className="sc-bczRLJ logtpp openstax-question"
+  className="sc-bczRLJ jqMCQk openstax-question"
   data-question-number={1}
   data-test-id="question"
 >
@@ -238,7 +238,7 @@ exports[`Question defaults collaborator_solutions 1`] = `
 
 exports[`Question defaults formats 1`] = `
 <div
-  className="sc-bczRLJ logtpp openstax-question"
+  className="sc-bczRLJ jqMCQk openstax-question"
   data-question-number={1}
   data-test-id="question"
 >
@@ -365,7 +365,7 @@ exports[`Question defaults formats 1`] = `
 
 exports[`Question matches snapshot 1`] = `
 <div
-  className="sc-bczRLJ logtpp openstax-question"
+  className="sc-bczRLJ jqMCQk openstax-question"
   data-question-number={1}
   data-test-id="question"
 >
@@ -483,7 +483,7 @@ exports[`Question matches snapshot 1`] = `
 
 exports[`Question renders exercise uid 1`] = `
 <div
-  className="sc-bczRLJ logtpp openstax-question"
+  className="sc-bczRLJ jqMCQk openstax-question"
   data-question-number={1}
   data-test-id="question"
 >
@@ -606,7 +606,7 @@ exports[`Question renders exercise uid 1`] = `
 
 exports[`Question renders formats 1`] = `
 <div
-  className="sc-bczRLJ logtpp openstax-question"
+  className="sc-bczRLJ jqMCQk openstax-question"
   data-question-number={1}
   data-test-id="question"
 >
@@ -736,7 +736,7 @@ exports[`Question renders formats 1`] = `
 
 exports[`Question renders solutions 1`] = `
 <div
-  className="sc-bczRLJ logtpp openstax-question"
+  className="sc-bczRLJ jqMCQk openstax-question"
   data-question-number={1}
   data-test-id="question"
 >

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -158,7 +158,6 @@ export const mixins = {
       transition: color ${transitions.answer}, border-color ${transitions.answer}, background-color ${transitions.answer};
       background-color: ${colors.palette.white};
       font-family: "Neue Helvetica W01", Helvetica, Arial, sans-serif;
-      padding-top: 1px;
     }
   `,
   answerColor: (values: { color: string, background: string }) => css`

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -158,6 +158,7 @@ export const mixins = {
       transition: color ${transitions.answer}, border-color ${transitions.answer}, background-color ${transitions.answer};
       background-color: ${colors.palette.white};
       font-family: "Neue Helvetica W01", Helvetica, Arial, sans-serif;
+      padding-top: 1px;
     }
   `,
   answerColor: (values: { color: string, background: string }) => css`

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -83,7 +83,7 @@ export const layouts = {
     verticalSpacing: "1rem",
     horizontalSpacing: "1rem",
     horizontalBuffer: "2.5rem",
-    bubbleSize: "2.4rem",
+    bubbleSize: "3.6rem",
     labelSpacing: "6.5rem",
     feedback: {
       popover: {
@@ -97,7 +97,7 @@ export const layouts = {
     arrow: {
       width: "16px",
       height: "8px",
-      edgeDistance: "4px",
+      edgeDistance: "9px",
     },
     horizontalSpacing: "0.8rem",
     verticalSpacing: "1rem",
@@ -157,6 +157,7 @@ export const mixins = {
       color: ${colors.answer.label.colorHover};
       transition: color ${transitions.answer}, border-color ${transitions.answer}, background-color ${transitions.answer};
       background-color: ${colors.palette.white};
+      font-family: "Neue Helvetica W01", Helvetica, Arial, sans-serif;
     }
   `,
   answerColor: (values: { color: string, background: string }) => css`
@@ -179,8 +180,11 @@ export const mixins = {
   answerCorrectText: () => css`
     content: 'correct answer';
     color: ${colors.answer.label.color};
-    margin-left: calc(-3 * ${layouts.answer.bubbleSize});
-    width: calc(3 * ${layouts.answer.bubbleSize});
+    margin-left: calc(-1.34 * ${layouts.answer.bubbleSize});
+    display: flex;
+    align-items: center;
+    height: ${layouts.answer.bubbleSize};
+    width: 4.8rem;
     text-align: center;
     font-size: 1.2rem;
     line-height: 1.2rem;
@@ -204,13 +208,13 @@ export const mixins = {
         &::after {
           ${mixins.answerCorrectText()}
           width: ${layouts.answer.bubbleSize} !important;
-          margin-left: calc(-${layouts.answer.bubbleSize} / 3.3);
+          margin-left: -0.1rem;
         }
       }
     }
   `,
   resetText: () => css`
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    font-family:  "Neue Helvetica W01", Helvetica, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, "Noto Sans", "Liberation Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
     font-style: normal;
     font-weight: 400;
     line-height: 1.6;


### PR DESCRIPTION
- Fix the loader not rendering in Safari
- Remove card min-width on desktop here too
- Make choice bubbles bigger and fix alignment (assume Helvetica webfont will be used and adjust for that.)
- Fix alignment of answer text when "correct answer" pushes down the flex height. You can see what this looks like in the screenshot below. It's not perfect, I think this should be refactored to a `grid` at some point and that will make correct/incorrect content text always match.
- Fix a story not creating a new prop object before overwriting attributes.
- Send a prop to fix a missing code coverage line

![image](https://user-images.githubusercontent.com/34174/206553986-b19c3d16-3c78-44fc-9e00-0bc8864f3634.png)
