### PR TITLE
Typeset MathJax in Content component

### DIFF
--- a/src/components/Content.tsx
+++ b/src/components/Content.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { typesetMath } from "../helpers/mathjax";
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 type ComponentType = keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>;
@@ -15,12 +16,20 @@ export interface ContentProps<T extends ComponentType | undefined> {
 export const Content = (<T extends ComponentType | undefined>(
   {html, component, block = false, ...props}: ContentProps<T>
 ) => {
+  const container = React.useRef(null);
+
+  React.useEffect(() => {
+    if (container.current) {
+      typesetMath(container.current);
+    }
+  }, [html]);
+
   if (component !== undefined) {
-    return React.cloneElement(component, {html, ...props});
+    return React.cloneElement(component, {html, ref: container, ...props});
   }
   if (block) {
-    return <div dangerouslySetInnerHTML={{ __html: html }} {...props} />;
+    return <div dangerouslySetInnerHTML={{ __html: html }} ref={container} {...props} />;
   } else {
-    return <span dangerouslySetInnerHTML={{ __html: html }} {...props} />;
+    return <span dangerouslySetInnerHTML={{ __html: html }} ref={container} {...props} />;
   }
 });

--- a/src/components/Exercise.stories.tsx
+++ b/src/components/Exercise.stories.tsx
@@ -396,7 +396,7 @@ This resonates with an unheard symphony of the universe, creating a multisensory
     exercise: {
       ...exerciseWithStepDataProps.exercise,
       context: `At the intersection of mathematics and abstract art, there is a realm where equations take on the characteristics of color and flavor. For
-instance, in this dimension, the quadratic formula <span data-math="x = \frac{{-b \pm \sqrt{{b^2-4ac}}}}{{2a}}"></span> might taste like a blend of sweet and
+instance, in this dimension, the quadratic formula <span data-math="x = \\frac{{-b \\pm \\sqrt{{b^2-4ac}}}}{{2a}}"></span> might taste like a blend of sweet and
 sour, with the variable <span data-math="a"></span> contributing sweetness, <span data-math="b"></span> sourness, and <span data-math="c"></span> a hint of
 bitterness. The discriminant <span data-math="b^2 - 4ac"></span> could perhaps alter the color of the equation, ranging from vibrant blue to fiery red.`,
       stimulus_html: `In a universe where equations like

--- a/src/components/Exercise.stories.tsx
+++ b/src/components/Exercise.stories.tsx
@@ -460,6 +460,23 @@ bitterness. The discriminant <span data-math="b^2 - 4ac"></span> could perhaps a
           content_html: `<span data-math="\\frac{\\pi}{2} + \\text{Red}"></span>`,
         }],
       }],
+    },
+    questionStates: {
+      ...exerciseWithQuestionStatesProps().questionStates,
+      '1': {
+        ...exerciseWithQuestionStatesProps().questionStates['1'],
+        solution: {
+          content_html: `<span data-math="\\sqrt[3]{\\text{Apple}}"></span>`,
+          solution_type: 'detailed'
+        }
+      },
+      '2': {
+        ...exerciseWithQuestionStatesProps().questionStates['1'],
+        solution: {
+          content_html: `<span data-math="e^{\\text{Blue}}"></span>`,
+          solution_type: 'detailed'
+        }
+      }
     }
   };
 

--- a/src/components/Exercise.stories.tsx
+++ b/src/components/Exercise.stories.tsx
@@ -338,8 +338,29 @@ export const Icons = () => {
 };
 
 export const MathJax = () => {
-  const props1: ExerciseWithStepDataProps = {
-    ...exerciseWithStepDataProps,
+  const [selectedAnswerId, setSelectedAnswerId] = useState<number>(0);
+  const [correctAnswerId, setCorrectAnswerId] = useState<number | undefined>(undefined);
+
+  const props1: ExerciseWithQuestionStatesProps = {
+    ...exerciseWithQuestionStatesProps(),
+    questionStates: {
+      '1': {
+        available_points: '1.0',
+        is_completed: false,
+        answer_id_order: ['1', '2'],
+        answer_id: selectedAnswerId,
+        free_response: '',
+        feedback_html: '',
+        correct_answer_id: '1',
+        correct_answer_feedback_html: '',
+        attempts_remaining: 0,
+        attempt_number: 0,
+        incorrectAnswerId: 0,
+        canAnswer: true,
+        needsSaved: true,
+        apiIsPending: false
+      }
+    },
     exercise: {
       ...exerciseWithStepDataProps.exercise,
       context: '',
@@ -352,23 +373,34 @@ export const MathJax = () => {
         is_answer_order_important: false,
         answers: [{
           id: '1',
-          correctness: undefined,
+          correctness: '1',
           content_html: `<span data-math="\\text{H}_2\\text{O} + \\sqrt[3]{\\text{Melodic Echo}}"></span>`,
+          feedback_html: `<span data-math="\\text{H}_2\\text{O} + \\sqrt[3]{\\text{Melodic Echo}}"></span> implies that water molecules are harmonizing with the cubic root of a Melodic Echo.
+This resonates with an unheard symphony of the universe, creating a multisensory mathematics that's both refreshing and melodious.`,
         }, {
           id: '2',
           correctness: undefined,
           content_html: `<span data-math="2 \\, \\text{NO}_2 \\to \\, \\text{N}_2\\text{O}_4 + \\text{Silent Whisper}"></span>`,
         }],
       }],
-    }
+    },
   };
 
-  const props2: ExerciseWithStepDataProps = {
-    ...exerciseWithStepDataProps,
+  if (correctAnswerId) {
+    props1.questionStates['1'].is_completed = true;
+    props1.questionStates['1'].correct_answer_feedback_html = props1.exercise.questions[0].answers[0].feedback_html || '';
+  }
+
+  const props2: ExerciseWithQuestionStatesProps = {
+    ...exerciseWithQuestionStatesProps(),
     exercise: {
       ...exerciseWithStepDataProps.exercise,
-      context: '',
-      stimulus_html: `In a universe where equations like <math xmlns="http://www.w3.org/1998/Math/MathML">
+      context: `At the intersection of mathematics and abstract art, there is a realm where equations take on the characteristics of color and flavor. For
+instance, in this dimension, the quadratic formula <span data-math="x = \frac{{-b \pm \sqrt{{b^2-4ac}}}}{{2a}}"></span> might taste like a blend of sweet and
+sour, with the variable <span data-math="a"></span> contributing sweetness, <span data-math="b"></span> sourness, and <span data-math="c"></span> a hint of
+bitterness. The discriminant <span data-math="b^2 - 4ac"></span> could perhaps alter the color of the equation, ranging from vibrant blue to fiery red.`,
+      stimulus_html: `In a universe where equations like
+<math xmlns="http://www.w3.org/1998/Math/MathML">
   <mi>x</mi>
   <mo>=</mo>
   <mrow class="MJX-TeXAtom-ORD">
@@ -433,7 +465,14 @@ export const MathJax = () => {
 
   return (
     <>
-      <Exercise {...props1} />
+      <Exercise {...props1}
+        onAnswerChange={(a: Omit<Answer, 'id'> & { id: number, question_id: number }) => {
+          setSelectedAnswerId(a.id)
+        }}
+        onAnswerSave={() => {
+          setCorrectAnswerId(1);
+        }}
+      />
       <Exercise {...props2} />
     </>
   );

--- a/src/components/Question.tsx
+++ b/src/components/Question.tsx
@@ -5,7 +5,6 @@ import classnames from 'classnames';
 import { ID, ExerciseQuestionData, Task } from 'src/types';
 import React, { ReactNode } from 'react';
 import { Content } from './Content';
-import { typesetMath } from '../helpers/mathjax';
 
 const StyledQuestion = styled.div`
 &.step-card-body {
@@ -275,32 +274,22 @@ export const Question = React.forwardRef((props: QuestionProps, ref: React.Forwa
       </div>;
   }
 
-  const container = React.useRef<HTMLDivElement>(null);
-
-  React.useEffect(() => {
-    if (container.current) {
-      typesetMath(container.current);
-    }
-  }, [question, props.correct_answer_feedback_html, props.feedback_html]);
-
   return (
-    <div ref={container}>
-      <StyledQuestion ref={ref} className={classes} data-question-number={questionNumber} data-test-id="question">
-        <QuestionHtml type="context" html={context} hidden={hidePreambles} />
-        <QuestionHtml type="stimulus" html={stimulus_html} hidden={hidePreambles} />
-        <QuestionHtml type="stem" html={stem_html} hidden={hidePreambles} questionNumber={questionNumber} />
-        {props.children}
+    <StyledQuestion ref={ref} className={classes} data-question-number={questionNumber} data-test-id="question">
+      <QuestionHtml type="context" html={context} hidden={hidePreambles} />
+      <QuestionHtml type="stimulus" html={stimulus_html} hidden={hidePreambles} />
+      <QuestionHtml type="stem" html={stem_html} hidden={hidePreambles} questionNumber={questionNumber} />
+      {props.children}
 
-        <AnswersTable
-          {...props}
-          onChangeAnswer={props.onChange}
-          hasCorrectAnswer={hasCorrectAnswer} />
+      <AnswersTable
+        {...props}
+        onChangeAnswer={props.onChange}
+        hasCorrectAnswer={hasCorrectAnswer} />
 
-        {solution}
-        {props.displayFormats ? <FormatsListing formats={formats} /> : undefined}
-        {exerciseUid}
-      </StyledQuestion>
-    </div>
+      {solution}
+      {props.displayFormats ? <FormatsListing formats={formats} /> : undefined}
+      {exerciseUid}
+    </StyledQuestion>
   );
 });
 

--- a/src/components/__snapshots__/Exercise.spec.tsx.snap
+++ b/src/components/__snapshots__/Exercise.spec.tsx.snap
@@ -68,111 +68,109 @@ exports[`Exercise using step data matches snapshot 1`] = `
       <div
         data-test-id="student-exercise-question"
       >
-        <div>
+        <div
+          className="sc-jqUVSM ghJTot openstax-question step-card-body"
+          data-question-number={1}
+          data-test-id="question"
+        >
           <div
-            className="sc-jqUVSM ghJTot openstax-question step-card-body"
-            data-question-number={1}
-            data-test-id="question"
+            className="answers-table"
           >
             <div
-              className="answers-table"
+              className="openstax-answer"
             >
-              <div
-                className="openstax-answer"
+              <section
+                className="answers-answer disabled answer-checked"
+                role="region"
               >
-                <section
-                  className="answers-answer disabled answer-checked"
-                  role="region"
+                <input
+                  checked={true}
+                  className="answer-input-box"
+                  disabled={true}
+                  id="1234@5-option-0"
+                  name="1234@5-options"
+                  onChange={[Function]}
+                  type="radio"
+                />
+                <label
+                  className="answer-label"
+                  htmlFor="1234@5-option-0"
                 >
-                  <input
-                    checked={true}
-                    className="answer-input-box"
-                    disabled={true}
-                    id="1234@5-option-0"
-                    name="1234@5-options"
-                    onChange={[Function]}
-                    type="radio"
-                  />
-                  <label
-                    className="answer-label"
-                    htmlFor="1234@5-option-0"
+                  <span
+                    className="answer-letter-wrapper"
+                  >
+                    <button
+                      aria-label="Selected Choice a:"
+                      className="answer-letter"
+                      data-test-id="answer-choice-a"
+                      disabled={true}
+                      onClick={[Function]}
+                    >
+                      a
+                    </button>
+                  </span>
+                  <div
+                    className="answer-answer"
                   >
                     <span
-                      className="answer-letter-wrapper"
-                    >
-                      <button
-                        aria-label="Selected Choice a:"
-                        className="answer-letter"
-                        data-test-id="answer-choice-a"
-                        disabled={true}
-                        onClick={[Function]}
-                      >
-                        a
-                      </button>
-                    </span>
-                    <div
-                      className="answer-answer"
-                    >
-                      <span
-                        className="answer-content"
-                        dangerouslySetInnerHTML={
-                          Object {
-                            "__html": "True",
-                          }
+                      className="answer-content"
+                      dangerouslySetInnerHTML={
+                        Object {
+                          "__html": "True",
                         }
-                      />
-                    </div>
-                  </label>
-                </section>
-              </div>
-              <div
-                className="openstax-answer"
+                      }
+                    />
+                  </div>
+                </label>
+              </section>
+            </div>
+            <div
+              className="openstax-answer"
+            >
+              <section
+                className="answers-answer disabled"
+                role="region"
               >
-                <section
-                  className="answers-answer disabled"
-                  role="region"
+                <input
+                  checked={false}
+                  className="answer-input-box"
+                  disabled={true}
+                  id="1234@5-option-1"
+                  name="1234@5-options"
+                  onChange={[Function]}
+                  type="radio"
+                />
+                <label
+                  className="answer-label"
+                  htmlFor="1234@5-option-1"
                 >
-                  <input
-                    checked={false}
-                    className="answer-input-box"
-                    disabled={true}
-                    id="1234@5-option-1"
-                    name="1234@5-options"
-                    onChange={[Function]}
-                    type="radio"
-                  />
-                  <label
-                    className="answer-label"
-                    htmlFor="1234@5-option-1"
+                  <span
+                    className="answer-letter-wrapper"
+                  >
+                    <button
+                      aria-label="Choice b:"
+                      className="answer-letter"
+                      data-test-id="answer-choice-b"
+                      disabled={true}
+                      onClick={[Function]}
+                    >
+                      b
+                    </button>
+                  </span>
+                  <div
+                    className="answer-answer"
                   >
                     <span
-                      className="answer-letter-wrapper"
-                    >
-                      <button
-                        aria-label="Choice b:"
-                        className="answer-letter"
-                        data-test-id="answer-choice-b"
-                        disabled={true}
-                        onClick={[Function]}
-                      >
-                        b
-                      </button>
-                    </span>
-                    <div
-                      className="answer-answer"
-                    >
-                      <span
-                        className="answer-content"
-                        dangerouslySetInnerHTML={
-                          Object {
-                            "__html": "False",
-                          }
+                      className="answer-content"
+                      dangerouslySetInnerHTML={
+                        Object {
+                          "__html": "False",
                         }
-                      />
-                    </div>
-                  </label>
-                </section>
-              </div>
+                      }
+                    />
+                  </div>
+                </label>
+              </section>
             </div>
           </div>
         </div>
@@ -274,111 +272,109 @@ exports[`Exercise with question state data matches snapshot 1`] = `
       <div
         data-test-id="student-exercise-question"
       >
-        <div>
+        <div
+          className="sc-jqUVSM ghJTot openstax-question step-card-body"
+          data-question-number={1}
+          data-test-id="question"
+        >
           <div
-            className="sc-jqUVSM ghJTot openstax-question step-card-body"
-            data-question-number={1}
-            data-test-id="question"
+            className="answers-table"
           >
             <div
-              className="answers-table"
+              className="openstax-answer"
             >
-              <div
-                className="openstax-answer"
+              <section
+                className="answers-answer disabled answer-checked"
+                role="region"
               >
-                <section
-                  className="answers-answer disabled answer-checked"
-                  role="region"
+                <input
+                  checked={true}
+                  className="answer-input-box"
+                  disabled={true}
+                  id="1-option-0"
+                  name="1-options"
+                  onChange={[Function]}
+                  type="radio"
+                />
+                <label
+                  className="answer-label"
+                  htmlFor="1-option-0"
                 >
-                  <input
-                    checked={true}
-                    className="answer-input-box"
-                    disabled={true}
-                    id="1-option-0"
-                    name="1-options"
-                    onChange={[Function]}
-                    type="radio"
-                  />
-                  <label
-                    className="answer-label"
-                    htmlFor="1-option-0"
+                  <span
+                    className="answer-letter-wrapper"
+                  >
+                    <button
+                      aria-label="Selected Choice a:"
+                      className="answer-letter"
+                      data-test-id="answer-choice-a"
+                      disabled={true}
+                      onClick={[Function]}
+                    >
+                      a
+                    </button>
+                  </span>
+                  <div
+                    className="answer-answer"
                   >
                     <span
-                      className="answer-letter-wrapper"
-                    >
-                      <button
-                        aria-label="Selected Choice a:"
-                        className="answer-letter"
-                        data-test-id="answer-choice-a"
-                        disabled={true}
-                        onClick={[Function]}
-                      >
-                        a
-                      </button>
-                    </span>
-                    <div
-                      className="answer-answer"
-                    >
-                      <span
-                        className="answer-content"
-                        dangerouslySetInnerHTML={
-                          Object {
-                            "__html": "True",
-                          }
+                      className="answer-content"
+                      dangerouslySetInnerHTML={
+                        Object {
+                          "__html": "True",
                         }
-                      />
-                    </div>
-                  </label>
-                </section>
-              </div>
-              <div
-                className="openstax-answer"
+                      }
+                    />
+                  </div>
+                </label>
+              </section>
+            </div>
+            <div
+              className="openstax-answer"
+            >
+              <section
+                className="answers-answer disabled"
+                role="region"
               >
-                <section
-                  className="answers-answer disabled"
-                  role="region"
+                <input
+                  checked={false}
+                  className="answer-input-box"
+                  disabled={true}
+                  id="1-option-1"
+                  name="1-options"
+                  onChange={[Function]}
+                  type="radio"
+                />
+                <label
+                  className="answer-label"
+                  htmlFor="1-option-1"
                 >
-                  <input
-                    checked={false}
-                    className="answer-input-box"
-                    disabled={true}
-                    id="1-option-1"
-                    name="1-options"
-                    onChange={[Function]}
-                    type="radio"
-                  />
-                  <label
-                    className="answer-label"
-                    htmlFor="1-option-1"
+                  <span
+                    className="answer-letter-wrapper"
+                  >
+                    <button
+                      aria-label="Choice b:"
+                      className="answer-letter"
+                      data-test-id="answer-choice-b"
+                      disabled={true}
+                      onClick={[Function]}
+                    >
+                      b
+                    </button>
+                  </span>
+                  <div
+                    className="answer-answer"
                   >
                     <span
-                      className="answer-letter-wrapper"
-                    >
-                      <button
-                        aria-label="Choice b:"
-                        className="answer-letter"
-                        data-test-id="answer-choice-b"
-                        disabled={true}
-                        onClick={[Function]}
-                      >
-                        b
-                      </button>
-                    </span>
-                    <div
-                      className="answer-answer"
-                    >
-                      <span
-                        className="answer-content"
-                        dangerouslySetInnerHTML={
-                          Object {
-                            "__html": "False",
-                          }
+                      className="answer-content"
+                      dangerouslySetInnerHTML={
+                        Object {
+                          "__html": "False",
                         }
-                      />
-                    </div>
-                  </label>
-                </section>
-              </div>
+                      }
+                    />
+                  </div>
+                </label>
+              </section>
             </div>
           </div>
         </div>
@@ -601,111 +597,109 @@ exports[`Exercise with question state data renders header icons with multiple ch
       <div
         data-test-id="student-exercise-question"
       >
-        <div>
+        <div
+          className="sc-jqUVSM ghJTot openstax-question step-card-body"
+          data-question-number={1}
+          data-test-id="question"
+        >
           <div
-            className="sc-jqUVSM ghJTot openstax-question step-card-body"
-            data-question-number={1}
-            data-test-id="question"
+            className="answers-table"
           >
             <div
-              className="answers-table"
+              className="openstax-answer"
             >
-              <div
-                className="openstax-answer"
+              <section
+                className="answers-answer disabled answer-checked"
+                role="region"
               >
-                <section
-                  className="answers-answer disabled answer-checked"
-                  role="region"
+                <input
+                  checked={true}
+                  className="answer-input-box"
+                  disabled={true}
+                  id="1-option-0"
+                  name="1-options"
+                  onChange={[Function]}
+                  type="radio"
+                />
+                <label
+                  className="answer-label"
+                  htmlFor="1-option-0"
                 >
-                  <input
-                    checked={true}
-                    className="answer-input-box"
-                    disabled={true}
-                    id="1-option-0"
-                    name="1-options"
-                    onChange={[Function]}
-                    type="radio"
-                  />
-                  <label
-                    className="answer-label"
-                    htmlFor="1-option-0"
+                  <span
+                    className="answer-letter-wrapper"
+                  >
+                    <button
+                      aria-label="Selected Choice a:"
+                      className="answer-letter"
+                      data-test-id="answer-choice-a"
+                      disabled={true}
+                      onClick={[Function]}
+                    >
+                      a
+                    </button>
+                  </span>
+                  <div
+                    className="answer-answer"
                   >
                     <span
-                      className="answer-letter-wrapper"
-                    >
-                      <button
-                        aria-label="Selected Choice a:"
-                        className="answer-letter"
-                        data-test-id="answer-choice-a"
-                        disabled={true}
-                        onClick={[Function]}
-                      >
-                        a
-                      </button>
-                    </span>
-                    <div
-                      className="answer-answer"
-                    >
-                      <span
-                        className="answer-content"
-                        dangerouslySetInnerHTML={
-                          Object {
-                            "__html": "True",
-                          }
+                      className="answer-content"
+                      dangerouslySetInnerHTML={
+                        Object {
+                          "__html": "True",
                         }
-                      />
-                    </div>
-                  </label>
-                </section>
-              </div>
-              <div
-                className="openstax-answer"
+                      }
+                    />
+                  </div>
+                </label>
+              </section>
+            </div>
+            <div
+              className="openstax-answer"
+            >
+              <section
+                className="answers-answer disabled"
+                role="region"
               >
-                <section
-                  className="answers-answer disabled"
-                  role="region"
+                <input
+                  checked={false}
+                  className="answer-input-box"
+                  disabled={true}
+                  id="1-option-1"
+                  name="1-options"
+                  onChange={[Function]}
+                  type="radio"
+                />
+                <label
+                  className="answer-label"
+                  htmlFor="1-option-1"
                 >
-                  <input
-                    checked={false}
-                    className="answer-input-box"
-                    disabled={true}
-                    id="1-option-1"
-                    name="1-options"
-                    onChange={[Function]}
-                    type="radio"
-                  />
-                  <label
-                    className="answer-label"
-                    htmlFor="1-option-1"
+                  <span
+                    className="answer-letter-wrapper"
+                  >
+                    <button
+                      aria-label="Choice b:"
+                      className="answer-letter"
+                      data-test-id="answer-choice-b"
+                      disabled={true}
+                      onClick={[Function]}
+                    >
+                      b
+                    </button>
+                  </span>
+                  <div
+                    className="answer-answer"
                   >
                     <span
-                      className="answer-letter-wrapper"
-                    >
-                      <button
-                        aria-label="Choice b:"
-                        className="answer-letter"
-                        data-test-id="answer-choice-b"
-                        disabled={true}
-                        onClick={[Function]}
-                      >
-                        b
-                      </button>
-                    </span>
-                    <div
-                      className="answer-answer"
-                    >
-                      <span
-                        className="answer-content"
-                        dangerouslySetInnerHTML={
-                          Object {
-                            "__html": "False",
-                          }
+                      className="answer-content"
+                      dangerouslySetInnerHTML={
+                        Object {
+                          "__html": "False",
                         }
-                      />
-                    </div>
-                  </label>
-                </section>
-              </div>
+                      }
+                    />
+                  </div>
+                </label>
+              </section>
             </div>
           </div>
         </div>
@@ -888,111 +882,109 @@ exports[`Exercise with question state data renders header icons with two-step ex
       <div
         data-test-id="student-exercise-question"
       >
-        <div>
+        <div
+          className="sc-jqUVSM ghJTot openstax-question step-card-body"
+          data-question-number={1}
+          data-test-id="question"
+        >
           <div
-            className="sc-jqUVSM ghJTot openstax-question step-card-body"
-            data-question-number={1}
-            data-test-id="question"
+            className="answers-table"
           >
             <div
-              className="answers-table"
+              className="openstax-answer"
             >
-              <div
-                className="openstax-answer"
+              <section
+                className="answers-answer disabled answer-checked"
+                role="region"
               >
-                <section
-                  className="answers-answer disabled answer-checked"
-                  role="region"
+                <input
+                  checked={true}
+                  className="answer-input-box"
+                  disabled={true}
+                  id="1-option-0"
+                  name="1-options"
+                  onChange={[Function]}
+                  type="radio"
+                />
+                <label
+                  className="answer-label"
+                  htmlFor="1-option-0"
                 >
-                  <input
-                    checked={true}
-                    className="answer-input-box"
-                    disabled={true}
-                    id="1-option-0"
-                    name="1-options"
-                    onChange={[Function]}
-                    type="radio"
-                  />
-                  <label
-                    className="answer-label"
-                    htmlFor="1-option-0"
+                  <span
+                    className="answer-letter-wrapper"
+                  >
+                    <button
+                      aria-label="Selected Choice a:"
+                      className="answer-letter"
+                      data-test-id="answer-choice-a"
+                      disabled={true}
+                      onClick={[Function]}
+                    >
+                      a
+                    </button>
+                  </span>
+                  <div
+                    className="answer-answer"
                   >
                     <span
-                      className="answer-letter-wrapper"
-                    >
-                      <button
-                        aria-label="Selected Choice a:"
-                        className="answer-letter"
-                        data-test-id="answer-choice-a"
-                        disabled={true}
-                        onClick={[Function]}
-                      >
-                        a
-                      </button>
-                    </span>
-                    <div
-                      className="answer-answer"
-                    >
-                      <span
-                        className="answer-content"
-                        dangerouslySetInnerHTML={
-                          Object {
-                            "__html": "True",
-                          }
+                      className="answer-content"
+                      dangerouslySetInnerHTML={
+                        Object {
+                          "__html": "True",
                         }
-                      />
-                    </div>
-                  </label>
-                </section>
-              </div>
-              <div
-                className="openstax-answer"
+                      }
+                    />
+                  </div>
+                </label>
+              </section>
+            </div>
+            <div
+              className="openstax-answer"
+            >
+              <section
+                className="answers-answer disabled"
+                role="region"
               >
-                <section
-                  className="answers-answer disabled"
-                  role="region"
+                <input
+                  checked={false}
+                  className="answer-input-box"
+                  disabled={true}
+                  id="1-option-1"
+                  name="1-options"
+                  onChange={[Function]}
+                  type="radio"
+                />
+                <label
+                  className="answer-label"
+                  htmlFor="1-option-1"
                 >
-                  <input
-                    checked={false}
-                    className="answer-input-box"
-                    disabled={true}
-                    id="1-option-1"
-                    name="1-options"
-                    onChange={[Function]}
-                    type="radio"
-                  />
-                  <label
-                    className="answer-label"
-                    htmlFor="1-option-1"
+                  <span
+                    className="answer-letter-wrapper"
+                  >
+                    <button
+                      aria-label="Choice b:"
+                      className="answer-letter"
+                      data-test-id="answer-choice-b"
+                      disabled={true}
+                      onClick={[Function]}
+                    >
+                      b
+                    </button>
+                  </span>
+                  <div
+                    className="answer-answer"
                   >
                     <span
-                      className="answer-letter-wrapper"
-                    >
-                      <button
-                        aria-label="Choice b:"
-                        className="answer-letter"
-                        data-test-id="answer-choice-b"
-                        disabled={true}
-                        onClick={[Function]}
-                      >
-                        b
-                      </button>
-                    </span>
-                    <div
-                      className="answer-answer"
-                    >
-                      <span
-                        className="answer-content"
-                        dangerouslySetInnerHTML={
-                          Object {
-                            "__html": "False",
-                          }
+                      className="answer-content"
+                      dangerouslySetInnerHTML={
+                        Object {
+                          "__html": "False",
                         }
-                      />
-                    </div>
-                  </label>
-                </section>
-              </div>
+                      }
+                    />
+                  </div>
+                </label>
+              </section>
             </div>
           </div>
         </div>
@@ -1094,111 +1086,109 @@ exports[`Exercise with question state data shows a detailed solution 1`] = `
       <div
         data-test-id="student-exercise-question"
       >
-        <div>
+        <div
+          className="sc-jqUVSM ghJTot openstax-question step-card-body"
+          data-question-number={1}
+          data-test-id="question"
+        >
           <div
-            className="sc-jqUVSM ghJTot openstax-question step-card-body"
-            data-question-number={1}
-            data-test-id="question"
+            className="answers-table"
           >
             <div
-              className="answers-table"
+              className="openstax-answer"
             >
-              <div
-                className="openstax-answer"
+              <section
+                className="answers-answer disabled answer-checked"
+                role="region"
               >
-                <section
-                  className="answers-answer disabled answer-checked"
-                  role="region"
+                <input
+                  checked={true}
+                  className="answer-input-box"
+                  disabled={true}
+                  id="1-option-0"
+                  name="1-options"
+                  onChange={[Function]}
+                  type="radio"
+                />
+                <label
+                  className="answer-label"
+                  htmlFor="1-option-0"
                 >
-                  <input
-                    checked={true}
-                    className="answer-input-box"
-                    disabled={true}
-                    id="1-option-0"
-                    name="1-options"
-                    onChange={[Function]}
-                    type="radio"
-                  />
-                  <label
-                    className="answer-label"
-                    htmlFor="1-option-0"
+                  <span
+                    className="answer-letter-wrapper"
+                  >
+                    <button
+                      aria-label="Selected Choice a:"
+                      className="answer-letter"
+                      data-test-id="answer-choice-a"
+                      disabled={true}
+                      onClick={[Function]}
+                    >
+                      a
+                    </button>
+                  </span>
+                  <div
+                    className="answer-answer"
                   >
                     <span
-                      className="answer-letter-wrapper"
-                    >
-                      <button
-                        aria-label="Selected Choice a:"
-                        className="answer-letter"
-                        data-test-id="answer-choice-a"
-                        disabled={true}
-                        onClick={[Function]}
-                      >
-                        a
-                      </button>
-                    </span>
-                    <div
-                      className="answer-answer"
-                    >
-                      <span
-                        className="answer-content"
-                        dangerouslySetInnerHTML={
-                          Object {
-                            "__html": "True",
-                          }
+                      className="answer-content"
+                      dangerouslySetInnerHTML={
+                        Object {
+                          "__html": "True",
                         }
-                      />
-                    </div>
-                  </label>
-                </section>
-              </div>
-              <div
-                className="openstax-answer"
+                      }
+                    />
+                  </div>
+                </label>
+              </section>
+            </div>
+            <div
+              className="openstax-answer"
+            >
+              <section
+                className="answers-answer disabled"
+                role="region"
               >
-                <section
-                  className="answers-answer disabled"
-                  role="region"
+                <input
+                  checked={false}
+                  className="answer-input-box"
+                  disabled={true}
+                  id="1-option-1"
+                  name="1-options"
+                  onChange={[Function]}
+                  type="radio"
+                />
+                <label
+                  className="answer-label"
+                  htmlFor="1-option-1"
                 >
-                  <input
-                    checked={false}
-                    className="answer-input-box"
-                    disabled={true}
-                    id="1-option-1"
-                    name="1-options"
-                    onChange={[Function]}
-                    type="radio"
-                  />
-                  <label
-                    className="answer-label"
-                    htmlFor="1-option-1"
+                  <span
+                    className="answer-letter-wrapper"
+                  >
+                    <button
+                      aria-label="Choice b:"
+                      className="answer-letter"
+                      data-test-id="answer-choice-b"
+                      disabled={true}
+                      onClick={[Function]}
+                    >
+                      b
+                    </button>
+                  </span>
+                  <div
+                    className="answer-answer"
                   >
                     <span
-                      className="answer-letter-wrapper"
-                    >
-                      <button
-                        aria-label="Choice b:"
-                        className="answer-letter"
-                        data-test-id="answer-choice-b"
-                        disabled={true}
-                        onClick={[Function]}
-                      >
-                        b
-                      </button>
-                    </span>
-                    <div
-                      className="answer-answer"
-                    >
-                      <span
-                        className="answer-content"
-                        dangerouslySetInnerHTML={
-                          Object {
-                            "__html": "False",
-                          }
+                      className="answer-content"
+                      dangerouslySetInnerHTML={
+                        Object {
+                          "__html": "False",
                         }
-                      />
-                    </div>
-                  </label>
-                </section>
-              </div>
+                      }
+                    />
+                  </div>
+                </label>
+              </section>
             </div>
           </div>
         </div>

--- a/src/components/__snapshots__/ExerciseQuestion.spec.tsx.snap
+++ b/src/components/__snapshots__/ExerciseQuestion.spec.tsx.snap
@@ -4,120 +4,118 @@ exports[`ExerciseQuestion matches snapshot 1`] = `
 <div
   data-test-id="student-exercise-question"
 >
-  <div>
+  <div
+    className="sc-gsnTZi kkcBIO openstax-question step-card-body"
+    data-question-number={1}
+    data-test-id="question"
+  >
     <div
-      className="sc-gsnTZi kkcBIO openstax-question step-card-body"
+      className="question-stem"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "Is this a question?",
+        }
+      }
       data-question-number={1}
-      data-test-id="question"
+    />
+    <div
+      className="answers-table"
     >
       <div
-        className="question-stem"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "Is this a question?",
-          }
-        }
-        data-question-number={1}
-      />
-      <div
-        className="answers-table"
+        className="openstax-answer"
       >
-        <div
-          className="openstax-answer"
+        <section
+          className="answers-answer disabled"
+          role="region"
         >
-          <section
-            className="answers-answer disabled"
-            role="region"
+          <input
+            checked={false}
+            className="answer-input-box"
+            disabled={true}
+            id="1-option-0"
+            name="1-options"
+            onChange={[Function]}
+            type="radio"
+          />
+          <label
+            className="answer-label"
+            htmlFor="1-option-0"
           >
-            <input
-              checked={false}
-              className="answer-input-box"
-              disabled={true}
-              id="1-option-0"
-              name="1-options"
-              onChange={[Function]}
-              type="radio"
-            />
-            <label
-              className="answer-label"
-              htmlFor="1-option-0"
+            <span
+              className="answer-letter-wrapper"
+            >
+              <button
+                aria-label="Choice a:"
+                className="answer-letter"
+                data-test-id="answer-choice-a"
+                disabled={true}
+                onClick={[Function]}
+              >
+                a
+              </button>
+            </span>
+            <div
+              className="answer-answer"
             >
               <span
-                className="answer-letter-wrapper"
-              >
-                <button
-                  aria-label="Choice a:"
-                  className="answer-letter"
-                  data-test-id="answer-choice-a"
-                  disabled={true}
-                  onClick={[Function]}
-                >
-                  a
-                </button>
-              </span>
-              <div
-                className="answer-answer"
-              >
-                <span
-                  className="answer-content"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "True",
-                    }
+                className="answer-content"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "True",
                   }
-                />
-              </div>
-            </label>
-          </section>
-        </div>
-        <div
-          className="openstax-answer"
+                }
+              />
+            </div>
+          </label>
+        </section>
+      </div>
+      <div
+        className="openstax-answer"
+      >
+        <section
+          className="answers-answer disabled"
+          role="region"
         >
-          <section
-            className="answers-answer disabled"
-            role="region"
+          <input
+            checked={false}
+            className="answer-input-box"
+            disabled={true}
+            id="1-option-1"
+            name="1-options"
+            onChange={[Function]}
+            type="radio"
+          />
+          <label
+            className="answer-label"
+            htmlFor="1-option-1"
           >
-            <input
-              checked={false}
-              className="answer-input-box"
-              disabled={true}
-              id="1-option-1"
-              name="1-options"
-              onChange={[Function]}
-              type="radio"
-            />
-            <label
-              className="answer-label"
-              htmlFor="1-option-1"
+            <span
+              className="answer-letter-wrapper"
+            >
+              <button
+                aria-label="Choice b:"
+                className="answer-letter"
+                data-test-id="answer-choice-b"
+                disabled={true}
+                onClick={[Function]}
+              >
+                b
+              </button>
+            </span>
+            <div
+              className="answer-answer"
             >
               <span
-                className="answer-letter-wrapper"
-              >
-                <button
-                  aria-label="Choice b:"
-                  className="answer-letter"
-                  data-test-id="answer-choice-b"
-                  disabled={true}
-                  onClick={[Function]}
-                >
-                  b
-                </button>
-              </span>
-              <div
-                className="answer-answer"
-              >
-                <span
-                  className="answer-content"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "False",
-                    }
+                className="answer-content"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "False",
                   }
-                />
-              </div>
-            </label>
-          </section>
-        </div>
+                }
+              />
+            </div>
+          </label>
+        </section>
       </div>
     </div>
   </div>
@@ -159,120 +157,118 @@ exports[`ExerciseQuestion renders Re-submit button 1`] = `
 <div
   data-test-id="student-exercise-question"
 >
-  <div>
+  <div
+    className="sc-gsnTZi kkcBIO openstax-question step-card-body has-incorrect-answer"
+    data-question-number={1}
+    data-test-id="question"
+  >
     <div
-      className="sc-gsnTZi kkcBIO openstax-question step-card-body has-incorrect-answer"
+      className="question-stem"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "Is this a question?",
+        }
+      }
       data-question-number={1}
-      data-test-id="question"
+    />
+    <div
+      className="answers-table"
     >
       <div
-        className="question-stem"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "Is this a question?",
-          }
-        }
-        data-question-number={1}
-      />
-      <div
-        className="answers-table"
+        className="openstax-answer"
       >
-        <div
-          className="openstax-answer"
+        <section
+          className="answers-answer answer-checked"
+          role="region"
         >
-          <section
-            className="answers-answer answer-checked"
-            role="region"
+          <input
+            checked={true}
+            className="answer-input-box"
+            disabled={false}
+            id="1-option-0"
+            name="1-options"
+            onChange={[Function]}
+            type="radio"
+          />
+          <label
+            className="answer-label"
+            htmlFor="1-option-0"
           >
-            <input
-              checked={true}
-              className="answer-input-box"
-              disabled={false}
-              id="1-option-0"
-              name="1-options"
-              onChange={[Function]}
-              type="radio"
-            />
-            <label
-              className="answer-label"
-              htmlFor="1-option-0"
+            <span
+              className="answer-letter-wrapper"
+            >
+              <button
+                aria-label="Selected Choice a:"
+                className="answer-letter"
+                data-test-id="answer-choice-a"
+                disabled={false}
+                onClick={[Function]}
+              >
+                a
+              </button>
+            </span>
+            <div
+              className="answer-answer"
             >
               <span
-                className="answer-letter-wrapper"
-              >
-                <button
-                  aria-label="Selected Choice a:"
-                  className="answer-letter"
-                  data-test-id="answer-choice-a"
-                  disabled={false}
-                  onClick={[Function]}
-                >
-                  a
-                </button>
-              </span>
-              <div
-                className="answer-answer"
-              >
-                <span
-                  className="answer-content"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "True",
-                    }
+                className="answer-content"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "True",
                   }
-                />
-              </div>
-            </label>
-          </section>
-        </div>
-        <div
-          className="openstax-answer"
+                }
+              />
+            </div>
+          </label>
+        </section>
+      </div>
+      <div
+        className="openstax-answer"
+      >
+        <section
+          className="answers-answer answer-incorrect"
+          role="region"
         >
-          <section
-            className="answers-answer answer-incorrect"
-            role="region"
+          <input
+            checked={false}
+            className="answer-input-box"
+            disabled={false}
+            id="1-option-1"
+            name="1-options"
+            onChange={[Function]}
+            type="radio"
+          />
+          <label
+            className="answer-label"
+            htmlFor="1-option-1"
           >
-            <input
-              checked={false}
-              className="answer-input-box"
-              disabled={false}
-              id="1-option-1"
-              name="1-options"
-              onChange={[Function]}
-              type="radio"
-            />
-            <label
-              className="answer-label"
-              htmlFor="1-option-1"
+            <span
+              className="answer-letter-wrapper"
+            >
+              <button
+                aria-label="Choice b:"
+                className="answer-letter"
+                data-test-id="answer-choice-b"
+                disabled={true}
+                onClick={[Function]}
+              >
+                b
+              </button>
+            </span>
+            <div
+              className="answer-answer"
             >
               <span
-                className="answer-letter-wrapper"
-              >
-                <button
-                  aria-label="Choice b:"
-                  className="answer-letter"
-                  data-test-id="answer-choice-b"
-                  disabled={true}
-                  onClick={[Function]}
-                >
-                  b
-                </button>
-              </span>
-              <div
-                className="answer-answer"
-              >
-                <span
-                  className="answer-content"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "False",
-                    }
+                className="answer-content"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "False",
                   }
-                />
-              </div>
-            </label>
-          </section>
-        </div>
+                }
+              />
+            </div>
+          </label>
+        </section>
       </div>
     </div>
   </div>
@@ -315,120 +311,118 @@ exports[`ExerciseQuestion renders Save button 1`] = `
 <div
   data-test-id="student-exercise-question"
 >
-  <div>
+  <div
+    className="sc-gsnTZi kkcBIO openstax-question step-card-body has-incorrect-answer"
+    data-question-number={1}
+    data-test-id="question"
+  >
     <div
-      className="sc-gsnTZi kkcBIO openstax-question step-card-body has-incorrect-answer"
+      className="question-stem"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "Is this a question?",
+        }
+      }
       data-question-number={1}
-      data-test-id="question"
+    />
+    <div
+      className="answers-table"
     >
       <div
-        className="question-stem"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "Is this a question?",
-          }
-        }
-        data-question-number={1}
-      />
-      <div
-        className="answers-table"
+        className="openstax-answer"
       >
-        <div
-          className="openstax-answer"
+        <section
+          className="answers-answer answer-checked"
+          role="region"
         >
-          <section
-            className="answers-answer answer-checked"
-            role="region"
+          <input
+            checked={true}
+            className="answer-input-box"
+            disabled={false}
+            id="1-option-0"
+            name="1-options"
+            onChange={[Function]}
+            type="radio"
+          />
+          <label
+            className="answer-label"
+            htmlFor="1-option-0"
           >
-            <input
-              checked={true}
-              className="answer-input-box"
-              disabled={false}
-              id="1-option-0"
-              name="1-options"
-              onChange={[Function]}
-              type="radio"
-            />
-            <label
-              className="answer-label"
-              htmlFor="1-option-0"
+            <span
+              className="answer-letter-wrapper"
+            >
+              <button
+                aria-label="Selected Choice a:"
+                className="answer-letter"
+                data-test-id="answer-choice-a"
+                disabled={false}
+                onClick={[Function]}
+              >
+                a
+              </button>
+            </span>
+            <div
+              className="answer-answer"
             >
               <span
-                className="answer-letter-wrapper"
-              >
-                <button
-                  aria-label="Selected Choice a:"
-                  className="answer-letter"
-                  data-test-id="answer-choice-a"
-                  disabled={false}
-                  onClick={[Function]}
-                >
-                  a
-                </button>
-              </span>
-              <div
-                className="answer-answer"
-              >
-                <span
-                  className="answer-content"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "True",
-                    }
+                className="answer-content"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "True",
                   }
-                />
-              </div>
-            </label>
-          </section>
-        </div>
-        <div
-          className="openstax-answer"
+                }
+              />
+            </div>
+          </label>
+        </section>
+      </div>
+      <div
+        className="openstax-answer"
+      >
+        <section
+          className="answers-answer answer-incorrect"
+          role="region"
         >
-          <section
-            className="answers-answer answer-incorrect"
-            role="region"
+          <input
+            checked={false}
+            className="answer-input-box"
+            disabled={false}
+            id="1-option-1"
+            name="1-options"
+            onChange={[Function]}
+            type="radio"
+          />
+          <label
+            className="answer-label"
+            htmlFor="1-option-1"
           >
-            <input
-              checked={false}
-              className="answer-input-box"
-              disabled={false}
-              id="1-option-1"
-              name="1-options"
-              onChange={[Function]}
-              type="radio"
-            />
-            <label
-              className="answer-label"
-              htmlFor="1-option-1"
+            <span
+              className="answer-letter-wrapper"
+            >
+              <button
+                aria-label="Choice b:"
+                className="answer-letter"
+                data-test-id="answer-choice-b"
+                disabled={true}
+                onClick={[Function]}
+              >
+                b
+              </button>
+            </span>
+            <div
+              className="answer-answer"
             >
               <span
-                className="answer-letter-wrapper"
-              >
-                <button
-                  aria-label="Choice b:"
-                  className="answer-letter"
-                  data-test-id="answer-choice-b"
-                  disabled={true}
-                  onClick={[Function]}
-                >
-                  b
-                </button>
-              </span>
-              <div
-                className="answer-answer"
-              >
-                <span
-                  className="answer-content"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "False",
-                    }
+                className="answer-content"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "False",
                   }
-                />
-              </div>
-            </label>
-          </section>
-        </div>
+                }
+              />
+            </div>
+          </label>
+        </section>
       </div>
     </div>
   </div>
@@ -471,120 +465,118 @@ exports[`ExerciseQuestion renders all attempts remaining 1`] = `
 <div
   data-test-id="student-exercise-question"
 >
-  <div>
+  <div
+    className="sc-gsnTZi kkcBIO openstax-question step-card-body"
+    data-question-number={1}
+    data-test-id="question"
+  >
     <div
-      className="sc-gsnTZi kkcBIO openstax-question step-card-body"
+      className="question-stem"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "Is this a question?",
+        }
+      }
       data-question-number={1}
-      data-test-id="question"
+    />
+    <div
+      className="answers-table"
     >
       <div
-        className="question-stem"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "Is this a question?",
-          }
-        }
-        data-question-number={1}
-      />
-      <div
-        className="answers-table"
+        className="openstax-answer"
       >
-        <div
-          className="openstax-answer"
+        <section
+          className="answers-answer"
+          role="region"
         >
-          <section
-            className="answers-answer"
-            role="region"
+          <input
+            checked={false}
+            className="answer-input-box"
+            disabled={false}
+            id="1-option-0"
+            name="1-options"
+            onChange={[Function]}
+            type="radio"
+          />
+          <label
+            className="answer-label"
+            htmlFor="1-option-0"
           >
-            <input
-              checked={false}
-              className="answer-input-box"
-              disabled={false}
-              id="1-option-0"
-              name="1-options"
-              onChange={[Function]}
-              type="radio"
-            />
-            <label
-              className="answer-label"
-              htmlFor="1-option-0"
+            <span
+              className="answer-letter-wrapper"
+            >
+              <button
+                aria-label="Choice a:"
+                className="answer-letter"
+                data-test-id="answer-choice-a"
+                disabled={false}
+                onClick={[Function]}
+              >
+                a
+              </button>
+            </span>
+            <div
+              className="answer-answer"
             >
               <span
-                className="answer-letter-wrapper"
-              >
-                <button
-                  aria-label="Choice a:"
-                  className="answer-letter"
-                  data-test-id="answer-choice-a"
-                  disabled={false}
-                  onClick={[Function]}
-                >
-                  a
-                </button>
-              </span>
-              <div
-                className="answer-answer"
-              >
-                <span
-                  className="answer-content"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "True",
-                    }
+                className="answer-content"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "True",
                   }
-                />
-              </div>
-            </label>
-          </section>
-        </div>
-        <div
-          className="openstax-answer"
+                }
+              />
+            </div>
+          </label>
+        </section>
+      </div>
+      <div
+        className="openstax-answer"
+      >
+        <section
+          className="answers-answer"
+          role="region"
         >
-          <section
-            className="answers-answer"
-            role="region"
+          <input
+            checked={false}
+            className="answer-input-box"
+            disabled={false}
+            id="1-option-1"
+            name="1-options"
+            onChange={[Function]}
+            type="radio"
+          />
+          <label
+            className="answer-label"
+            htmlFor="1-option-1"
           >
-            <input
-              checked={false}
-              className="answer-input-box"
-              disabled={false}
-              id="1-option-1"
-              name="1-options"
-              onChange={[Function]}
-              type="radio"
-            />
-            <label
-              className="answer-label"
-              htmlFor="1-option-1"
+            <span
+              className="answer-letter-wrapper"
+            >
+              <button
+                aria-label="Choice b:"
+                className="answer-letter"
+                data-test-id="answer-choice-b"
+                disabled={false}
+                onClick={[Function]}
+              >
+                b
+              </button>
+            </span>
+            <div
+              className="answer-answer"
             >
               <span
-                className="answer-letter-wrapper"
-              >
-                <button
-                  aria-label="Choice b:"
-                  className="answer-letter"
-                  data-test-id="answer-choice-b"
-                  disabled={false}
-                  onClick={[Function]}
-                >
-                  b
-                </button>
-              </span>
-              <div
-                className="answer-answer"
-              >
-                <span
-                  className="answer-content"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "False",
-                    }
+                className="answer-content"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "False",
                   }
-                />
-              </div>
-            </label>
-          </section>
-        </div>
+                }
+              />
+            </div>
+          </label>
+        </section>
       </div>
     </div>
   </div>
@@ -633,120 +625,118 @@ exports[`ExerciseQuestion renders continue button (unused?) 1`] = `
 <div
   data-test-id="student-exercise-question"
 >
-  <div>
+  <div
+    className="sc-gsnTZi kkcBIO openstax-question step-card-body has-incorrect-answer"
+    data-question-number={1}
+    data-test-id="question"
+  >
     <div
-      className="sc-gsnTZi kkcBIO openstax-question step-card-body has-incorrect-answer"
+      className="question-stem"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "Is this a question?",
+        }
+      }
       data-question-number={1}
-      data-test-id="question"
+    />
+    <div
+      className="answers-table"
     >
       <div
-        className="question-stem"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "Is this a question?",
-          }
-        }
-        data-question-number={1}
-      />
-      <div
-        className="answers-table"
+        className="openstax-answer"
       >
-        <div
-          className="openstax-answer"
+        <section
+          className="answers-answer disabled"
+          role="region"
         >
-          <section
-            className="answers-answer disabled"
-            role="region"
+          <input
+            checked={false}
+            className="answer-input-box"
+            disabled={true}
+            id="1-option-0"
+            name="1-options"
+            onChange={[Function]}
+            type="radio"
+          />
+          <label
+            className="answer-label"
+            htmlFor="1-option-0"
           >
-            <input
-              checked={false}
-              className="answer-input-box"
-              disabled={true}
-              id="1-option-0"
-              name="1-options"
-              onChange={[Function]}
-              type="radio"
-            />
-            <label
-              className="answer-label"
-              htmlFor="1-option-0"
+            <span
+              className="answer-letter-wrapper"
+            >
+              <button
+                aria-label="Choice a:"
+                className="answer-letter"
+                data-test-id="answer-choice-a"
+                disabled={true}
+                onClick={[Function]}
+              >
+                a
+              </button>
+            </span>
+            <div
+              className="answer-answer"
             >
               <span
-                className="answer-letter-wrapper"
-              >
-                <button
-                  aria-label="Choice a:"
-                  className="answer-letter"
-                  data-test-id="answer-choice-a"
-                  disabled={true}
-                  onClick={[Function]}
-                >
-                  a
-                </button>
-              </span>
-              <div
-                className="answer-answer"
-              >
-                <span
-                  className="answer-content"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "True",
-                    }
+                className="answer-content"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "True",
                   }
-                />
-              </div>
-            </label>
-          </section>
-        </div>
-        <div
-          className="openstax-answer"
+                }
+              />
+            </div>
+          </label>
+        </section>
+      </div>
+      <div
+        className="openstax-answer"
+      >
+        <section
+          className="answers-answer disabled answer-incorrect"
+          role="region"
         >
-          <section
-            className="answers-answer disabled answer-incorrect"
-            role="region"
+          <input
+            checked={false}
+            className="answer-input-box"
+            disabled={true}
+            id="1-option-1"
+            name="1-options"
+            onChange={[Function]}
+            type="radio"
+          />
+          <label
+            className="answer-label"
+            htmlFor="1-option-1"
           >
-            <input
-              checked={false}
-              className="answer-input-box"
-              disabled={true}
-              id="1-option-1"
-              name="1-options"
-              onChange={[Function]}
-              type="radio"
-            />
-            <label
-              className="answer-label"
-              htmlFor="1-option-1"
+            <span
+              className="answer-letter-wrapper"
+            >
+              <button
+                aria-label="Choice b:"
+                className="answer-letter"
+                data-test-id="answer-choice-b"
+                disabled={true}
+                onClick={[Function]}
+              >
+                b
+              </button>
+            </span>
+            <div
+              className="answer-answer"
             >
               <span
-                className="answer-letter-wrapper"
-              >
-                <button
-                  aria-label="Choice b:"
-                  className="answer-letter"
-                  data-test-id="answer-choice-b"
-                  disabled={true}
-                  onClick={[Function]}
-                >
-                  b
-                </button>
-              </span>
-              <div
-                className="answer-answer"
-              >
-                <span
-                  className="answer-content"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "False",
-                    }
+                className="answer-content"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "False",
                   }
-                />
-              </div>
-            </label>
-          </section>
-        </div>
+                }
+              />
+            </div>
+          </label>
+        </section>
       </div>
     </div>
   </div>
@@ -788,102 +778,100 @@ exports[`ExerciseQuestion renders detailed solution and published comments 1`] =
 <div
   data-test-id="student-exercise-question"
 >
-  <div>
+  <div
+    className="sc-gsnTZi kkcBIO openstax-question step-card-body has-correct-answer has-incorrect-answer"
+    data-question-number={1}
+    data-test-id="question"
+  >
     <div
-      className="sc-gsnTZi kkcBIO openstax-question step-card-body has-correct-answer has-incorrect-answer"
+      className="question-stem"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "Is this a question?",
+        }
+      }
       data-question-number={1}
-      data-test-id="question"
+    />
+    <div
+      className="answers-table"
     >
       <div
-        className="question-stem"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "Is this a question?",
-          }
-        }
-        data-question-number={1}
-      />
-      <div
-        className="answers-table"
+        className="openstax-answer"
       >
-        <div
-          className="openstax-answer"
+        <section
+          className="answers-answer disabled answer-correct"
+          role="region"
         >
-          <section
-            className="answers-answer disabled answer-correct"
-            role="region"
+          <label
+            className="answer-label"
+            htmlFor="1-option-0"
           >
-            <label
-              className="answer-label"
-              htmlFor="1-option-0"
+            <span
+              className="answer-letter-wrapper"
+            >
+              <button
+                aria-label="Choice a(Correct Answer):"
+                className="answer-letter"
+                data-test-id="answer-choice-a"
+                disabled={true}
+                onClick={[Function]}
+              >
+                a
+              </button>
+            </span>
+            <div
+              className="answer-answer"
             >
               <span
-                className="answer-letter-wrapper"
-              >
-                <button
-                  aria-label="Choice a(Correct Answer):"
-                  className="answer-letter"
-                  data-test-id="answer-choice-a"
-                  disabled={true}
-                  onClick={[Function]}
-                >
-                  a
-                </button>
-              </span>
-              <div
-                className="answer-answer"
-              >
-                <span
-                  className="answer-content"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "True",
-                    }
+                className="answer-content"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "True",
                   }
-                />
-              </div>
-            </label>
-          </section>
-        </div>
-        <div
-          className="openstax-answer"
+                }
+              />
+            </div>
+          </label>
+        </section>
+      </div>
+      <div
+        className="openstax-answer"
+      >
+        <section
+          className="answers-answer disabled answer-incorrect"
+          role="region"
         >
-          <section
-            className="answers-answer disabled answer-incorrect"
-            role="region"
+          <label
+            className="answer-label"
+            htmlFor="1-option-1"
           >
-            <label
-              className="answer-label"
-              htmlFor="1-option-1"
+            <span
+              className="answer-letter-wrapper"
+            >
+              <button
+                aria-label="Choice b(Incorrect Answer):"
+                className="answer-letter"
+                data-test-id="answer-choice-b"
+                disabled={true}
+                onClick={[Function]}
+              >
+                b
+              </button>
+            </span>
+            <div
+              className="answer-answer"
             >
               <span
-                className="answer-letter-wrapper"
-              >
-                <button
-                  aria-label="Choice b(Incorrect Answer):"
-                  className="answer-letter"
-                  data-test-id="answer-choice-b"
-                  disabled={true}
-                  onClick={[Function]}
-                >
-                  b
-                </button>
-              </span>
-              <div
-                className="answer-answer"
-              >
-                <span
-                  className="answer-content"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "False",
-                    }
+                className="answer-content"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "False",
                   }
-                />
-              </div>
-            </label>
-          </section>
-        </div>
+                }
+              />
+            </div>
+          </label>
+        </section>
       </div>
     </div>
   </div>
@@ -944,125 +932,123 @@ exports[`ExerciseQuestion renders free response 1`] = `
 <div
   data-test-id="student-exercise-question"
 >
-  <div>
+  <div
+    className="sc-gsnTZi kkcBIO openstax-question step-card-body"
+    data-question-number={1}
+    data-test-id="question"
+  >
     <div
-      className="sc-gsnTZi kkcBIO openstax-question step-card-body"
+      className="question-stem"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "Is this a question?",
+        }
+      }
       data-question-number={1}
-      data-test-id="question"
+    />
+    <div
+      className="free-response"
+    >
+      A free response
+    </div>
+    <div
+      className="answers-table"
     >
       <div
-        className="question-stem"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "Is this a question?",
-          }
-        }
-        data-question-number={1}
-      />
-      <div
-        className="free-response"
+        className="openstax-answer"
       >
-        A free response
+        <section
+          className="answers-answer disabled"
+          role="region"
+        >
+          <input
+            checked={false}
+            className="answer-input-box"
+            disabled={true}
+            id="1-option-0"
+            name="1-options"
+            onChange={[Function]}
+            type="radio"
+          />
+          <label
+            className="answer-label"
+            htmlFor="1-option-0"
+          >
+            <span
+              className="answer-letter-wrapper"
+            >
+              <button
+                aria-label="Choice a:"
+                className="answer-letter"
+                data-test-id="answer-choice-a"
+                disabled={true}
+                onClick={[Function]}
+              >
+                a
+              </button>
+            </span>
+            <div
+              className="answer-answer"
+            >
+              <span
+                className="answer-content"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "True",
+                  }
+                }
+              />
+            </div>
+          </label>
+        </section>
       </div>
       <div
-        className="answers-table"
+        className="openstax-answer"
       >
-        <div
-          className="openstax-answer"
+        <section
+          className="answers-answer disabled"
+          role="region"
         >
-          <section
-            className="answers-answer disabled"
-            role="region"
+          <input
+            checked={false}
+            className="answer-input-box"
+            disabled={true}
+            id="1-option-1"
+            name="1-options"
+            onChange={[Function]}
+            type="radio"
+          />
+          <label
+            className="answer-label"
+            htmlFor="1-option-1"
           >
-            <input
-              checked={false}
-              className="answer-input-box"
-              disabled={true}
-              id="1-option-0"
-              name="1-options"
-              onChange={[Function]}
-              type="radio"
-            />
-            <label
-              className="answer-label"
-              htmlFor="1-option-0"
+            <span
+              className="answer-letter-wrapper"
+            >
+              <button
+                aria-label="Choice b:"
+                className="answer-letter"
+                data-test-id="answer-choice-b"
+                disabled={true}
+                onClick={[Function]}
+              >
+                b
+              </button>
+            </span>
+            <div
+              className="answer-answer"
             >
               <span
-                className="answer-letter-wrapper"
-              >
-                <button
-                  aria-label="Choice a:"
-                  className="answer-letter"
-                  data-test-id="answer-choice-a"
-                  disabled={true}
-                  onClick={[Function]}
-                >
-                  a
-                </button>
-              </span>
-              <div
-                className="answer-answer"
-              >
-                <span
-                  className="answer-content"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "True",
-                    }
+                className="answer-content"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "False",
                   }
-                />
-              </div>
-            </label>
-          </section>
-        </div>
-        <div
-          className="openstax-answer"
-        >
-          <section
-            className="answers-answer disabled"
-            role="region"
-          >
-            <input
-              checked={false}
-              className="answer-input-box"
-              disabled={true}
-              id="1-option-1"
-              name="1-options"
-              onChange={[Function]}
-              type="radio"
-            />
-            <label
-              className="answer-label"
-              htmlFor="1-option-1"
-            >
-              <span
-                className="answer-letter-wrapper"
-              >
-                <button
-                  aria-label="Choice b:"
-                  className="answer-letter"
-                  data-test-id="answer-choice-b"
-                  disabled={true}
-                  onClick={[Function]}
-                >
-                  b
-                </button>
-              </span>
-              <div
-                className="answer-answer"
-              >
-                <span
-                  className="answer-content"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "False",
-                    }
-                  }
-                />
-              </div>
-            </label>
-          </section>
-        </div>
+                }
+              />
+            </div>
+          </label>
+        </section>
       </div>
     </div>
   </div>
@@ -1104,120 +1090,118 @@ exports[`ExerciseQuestion renders no attempts remaining 1`] = `
 <div
   data-test-id="student-exercise-question"
 >
-  <div>
+  <div
+    className="sc-gsnTZi kkcBIO openstax-question step-card-body has-incorrect-answer"
+    data-question-number={1}
+    data-test-id="question"
+  >
     <div
-      className="sc-gsnTZi kkcBIO openstax-question step-card-body has-incorrect-answer"
+      className="question-stem"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "Is this a question?",
+        }
+      }
       data-question-number={1}
-      data-test-id="question"
+    />
+    <div
+      className="answers-table"
     >
       <div
-        className="question-stem"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "Is this a question?",
-          }
-        }
-        data-question-number={1}
-      />
-      <div
-        className="answers-table"
+        className="openstax-answer"
       >
-        <div
-          className="openstax-answer"
+        <section
+          className="answers-answer disabled"
+          role="region"
         >
-          <section
-            className="answers-answer disabled"
-            role="region"
+          <input
+            checked={false}
+            className="answer-input-box"
+            disabled={true}
+            id="1-option-0"
+            name="1-options"
+            onChange={[Function]}
+            type="radio"
+          />
+          <label
+            className="answer-label"
+            htmlFor="1-option-0"
           >
-            <input
-              checked={false}
-              className="answer-input-box"
-              disabled={true}
-              id="1-option-0"
-              name="1-options"
-              onChange={[Function]}
-              type="radio"
-            />
-            <label
-              className="answer-label"
-              htmlFor="1-option-0"
+            <span
+              className="answer-letter-wrapper"
+            >
+              <button
+                aria-label="Choice a:"
+                className="answer-letter"
+                data-test-id="answer-choice-a"
+                disabled={true}
+                onClick={[Function]}
+              >
+                a
+              </button>
+            </span>
+            <div
+              className="answer-answer"
             >
               <span
-                className="answer-letter-wrapper"
-              >
-                <button
-                  aria-label="Choice a:"
-                  className="answer-letter"
-                  data-test-id="answer-choice-a"
-                  disabled={true}
-                  onClick={[Function]}
-                >
-                  a
-                </button>
-              </span>
-              <div
-                className="answer-answer"
-              >
-                <span
-                  className="answer-content"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "True",
-                    }
+                className="answer-content"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "True",
                   }
-                />
-              </div>
-            </label>
-          </section>
-        </div>
-        <div
-          className="openstax-answer"
+                }
+              />
+            </div>
+          </label>
+        </section>
+      </div>
+      <div
+        className="openstax-answer"
+      >
+        <section
+          className="answers-answer disabled answer-incorrect"
+          role="region"
         >
-          <section
-            className="answers-answer disabled answer-incorrect"
-            role="region"
+          <input
+            checked={false}
+            className="answer-input-box"
+            disabled={true}
+            id="1-option-1"
+            name="1-options"
+            onChange={[Function]}
+            type="radio"
+          />
+          <label
+            className="answer-label"
+            htmlFor="1-option-1"
           >
-            <input
-              checked={false}
-              className="answer-input-box"
-              disabled={true}
-              id="1-option-1"
-              name="1-options"
-              onChange={[Function]}
-              type="radio"
-            />
-            <label
-              className="answer-label"
-              htmlFor="1-option-1"
+            <span
+              className="answer-letter-wrapper"
+            >
+              <button
+                aria-label="Choice b:"
+                className="answer-letter"
+                data-test-id="answer-choice-b"
+                disabled={true}
+                onClick={[Function]}
+              >
+                b
+              </button>
+            </span>
+            <div
+              className="answer-answer"
             >
               <span
-                className="answer-letter-wrapper"
-              >
-                <button
-                  aria-label="Choice b:"
-                  className="answer-letter"
-                  data-test-id="answer-choice-b"
-                  disabled={true}
-                  onClick={[Function]}
-                >
-                  b
-                </button>
-              </span>
-              <div
-                className="answer-answer"
-              >
-                <span
-                  className="answer-content"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "False",
-                    }
+                className="answer-content"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "False",
                   }
-                />
-              </div>
-            </label>
-          </section>
-        </div>
+                }
+              />
+            </div>
+          </label>
+        </section>
       </div>
     </div>
   </div>
@@ -1259,120 +1243,118 @@ exports[`ExerciseQuestion renders some attempts remaining 1`] = `
 <div
   data-test-id="student-exercise-question"
 >
-  <div>
+  <div
+    className="sc-gsnTZi kkcBIO openstax-question step-card-body has-incorrect-answer"
+    data-question-number={1}
+    data-test-id="question"
+  >
     <div
-      className="sc-gsnTZi kkcBIO openstax-question step-card-body has-incorrect-answer"
+      className="question-stem"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "Is this a question?",
+        }
+      }
       data-question-number={1}
-      data-test-id="question"
+    />
+    <div
+      className="answers-table"
     >
       <div
-        className="question-stem"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "Is this a question?",
-          }
-        }
-        data-question-number={1}
-      />
-      <div
-        className="answers-table"
+        className="openstax-answer"
       >
-        <div
-          className="openstax-answer"
+        <section
+          className="answers-answer"
+          role="region"
         >
-          <section
-            className="answers-answer"
-            role="region"
+          <input
+            checked={false}
+            className="answer-input-box"
+            disabled={false}
+            id="1-option-0"
+            name="1-options"
+            onChange={[Function]}
+            type="radio"
+          />
+          <label
+            className="answer-label"
+            htmlFor="1-option-0"
           >
-            <input
-              checked={false}
-              className="answer-input-box"
-              disabled={false}
-              id="1-option-0"
-              name="1-options"
-              onChange={[Function]}
-              type="radio"
-            />
-            <label
-              className="answer-label"
-              htmlFor="1-option-0"
+            <span
+              className="answer-letter-wrapper"
+            >
+              <button
+                aria-label="Choice a:"
+                className="answer-letter"
+                data-test-id="answer-choice-a"
+                disabled={false}
+                onClick={[Function]}
+              >
+                a
+              </button>
+            </span>
+            <div
+              className="answer-answer"
             >
               <span
-                className="answer-letter-wrapper"
-              >
-                <button
-                  aria-label="Choice a:"
-                  className="answer-letter"
-                  data-test-id="answer-choice-a"
-                  disabled={false}
-                  onClick={[Function]}
-                >
-                  a
-                </button>
-              </span>
-              <div
-                className="answer-answer"
-              >
-                <span
-                  className="answer-content"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "True",
-                    }
+                className="answer-content"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "True",
                   }
-                />
-              </div>
-            </label>
-          </section>
-        </div>
-        <div
-          className="openstax-answer"
+                }
+              />
+            </div>
+          </label>
+        </section>
+      </div>
+      <div
+        className="openstax-answer"
+      >
+        <section
+          className="answers-answer answer-incorrect"
+          role="region"
         >
-          <section
-            className="answers-answer answer-incorrect"
-            role="region"
+          <input
+            checked={false}
+            className="answer-input-box"
+            disabled={false}
+            id="1-option-1"
+            name="1-options"
+            onChange={[Function]}
+            type="radio"
+          />
+          <label
+            className="answer-label"
+            htmlFor="1-option-1"
           >
-            <input
-              checked={false}
-              className="answer-input-box"
-              disabled={false}
-              id="1-option-1"
-              name="1-options"
-              onChange={[Function]}
-              type="radio"
-            />
-            <label
-              className="answer-label"
-              htmlFor="1-option-1"
+            <span
+              className="answer-letter-wrapper"
+            >
+              <button
+                aria-label="Choice b:"
+                className="answer-letter"
+                data-test-id="answer-choice-b"
+                disabled={true}
+                onClick={[Function]}
+              >
+                b
+              </button>
+            </span>
+            <div
+              className="answer-answer"
             >
               <span
-                className="answer-letter-wrapper"
-              >
-                <button
-                  aria-label="Choice b:"
-                  className="answer-letter"
-                  data-test-id="answer-choice-b"
-                  disabled={true}
-                  onClick={[Function]}
-                >
-                  b
-                </button>
-              </span>
-              <div
-                className="answer-answer"
-              >
-                <span
-                  className="answer-content"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "False",
-                    }
+                className="answer-content"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "False",
                   }
-                />
-              </div>
-            </label>
-          </section>
-        </div>
+                }
+              />
+            </div>
+          </label>
+        </section>
       </div>
     </div>
   </div>

--- a/src/components/__snapshots__/Question.spec.tsx.snap
+++ b/src/components/__snapshots__/Question.spec.tsx.snap
@@ -1,884 +1,870 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Question defaults QuestionHtml html 1`] = `
-<div>
+<div
+  className="sc-bczRLJ jqMCQk openstax-question"
+  data-question-number={1}
+  data-test-id="question"
+>
   <div
-    className="sc-bczRLJ jqMCQk openstax-question"
+    className="question-stem"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "Is this a question?",
+      }
+    }
     data-question-number={1}
-    data-test-id="question"
+  />
+  <div
+    className="answers-table"
   >
     <div
-      className="question-stem"
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "Is this a question?",
-        }
-      }
-      data-question-number={1}
-    />
-    <div
-      className="answers-table"
+      className="openstax-answer"
     >
-      <div
-        className="openstax-answer"
+      <section
+        className="answers-answer disabled"
+        role="region"
       >
-        <section
-          className="answers-answer disabled"
-          role="region"
+        <input
+          checked={false}
+          className="answer-input-box"
+          disabled={true}
+          id="1-option-0"
+          name="1-options"
+          onChange={[Function]}
+          type="radio"
+        />
+        <label
+          className="answer-label"
+          htmlFor="1-option-0"
         >
-          <input
-            checked={false}
-            className="answer-input-box"
-            disabled={true}
-            id="1-option-0"
-            name="1-options"
-            onChange={[Function]}
-            type="radio"
-          />
-          <label
-            className="answer-label"
-            htmlFor="1-option-0"
+          <span
+            className="answer-letter-wrapper"
+          >
+            <button
+              aria-label="Choice a:"
+              className="answer-letter"
+              data-test-id="answer-choice-a"
+              disabled={true}
+              onClick={[Function]}
+            >
+              a
+            </button>
+          </span>
+          <div
+            className="answer-answer"
           >
             <span
-              className="answer-letter-wrapper"
-            >
-              <button
-                aria-label="Choice a:"
-                className="answer-letter"
-                data-test-id="answer-choice-a"
-                disabled={true}
-                onClick={[Function]}
-              >
-                a
-              </button>
-            </span>
-            <div
-              className="answer-answer"
-            >
-              <span
-                className="answer-content"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "True",
-                  }
+              className="answer-content"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "True",
                 }
-              />
-            </div>
-          </label>
-        </section>
-      </div>
-      <div
-        className="openstax-answer"
+              }
+            />
+          </div>
+        </label>
+      </section>
+    </div>
+    <div
+      className="openstax-answer"
+    >
+      <section
+        className="answers-answer disabled"
+        role="region"
       >
-        <section
-          className="answers-answer disabled"
-          role="region"
+        <input
+          checked={false}
+          className="answer-input-box"
+          disabled={true}
+          id="1-option-1"
+          name="1-options"
+          onChange={[Function]}
+          type="radio"
+        />
+        <label
+          className="answer-label"
+          htmlFor="1-option-1"
         >
-          <input
-            checked={false}
-            className="answer-input-box"
-            disabled={true}
-            id="1-option-1"
-            name="1-options"
-            onChange={[Function]}
-            type="radio"
-          />
-          <label
-            className="answer-label"
-            htmlFor="1-option-1"
+          <span
+            className="answer-letter-wrapper"
+          >
+            <button
+              aria-label="Choice b:"
+              className="answer-letter"
+              data-test-id="answer-choice-b"
+              disabled={true}
+              onClick={[Function]}
+            >
+              b
+            </button>
+          </span>
+          <div
+            className="answer-answer"
           >
             <span
-              className="answer-letter-wrapper"
-            >
-              <button
-                aria-label="Choice b:"
-                className="answer-letter"
-                data-test-id="answer-choice-b"
-                disabled={true}
-                onClick={[Function]}
-              >
-                b
-              </button>
-            </span>
-            <div
-              className="answer-answer"
-            >
-              <span
-                className="answer-content"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "False",
-                  }
+              className="answer-content"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "False",
                 }
-              />
-            </div>
-          </label>
-        </section>
-      </div>
+              }
+            />
+          </div>
+        </label>
+      </section>
     </div>
   </div>
 </div>
 `;
 
 exports[`Question defaults collaborator_solutions 1`] = `
-<div>
+<div
+  className="sc-bczRLJ jqMCQk openstax-question"
+  data-question-number={1}
+  data-test-id="question"
+>
   <div
-    className="sc-bczRLJ jqMCQk openstax-question"
+    className="question-stem"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "Is this a question?",
+      }
+    }
     data-question-number={1}
-    data-test-id="question"
+  />
+  <div
+    className="answers-table"
   >
     <div
-      className="question-stem"
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "Is this a question?",
-        }
-      }
-      data-question-number={1}
-    />
-    <div
-      className="answers-table"
+      className="openstax-answer"
     >
-      <div
-        className="openstax-answer"
+      <section
+        className="answers-answer disabled"
+        role="region"
       >
-        <section
-          className="answers-answer disabled"
-          role="region"
+        <input
+          checked={false}
+          className="answer-input-box"
+          disabled={true}
+          id="1-option-0"
+          name="1-options"
+          onChange={[Function]}
+          type="radio"
+        />
+        <label
+          className="answer-label"
+          htmlFor="1-option-0"
         >
-          <input
-            checked={false}
-            className="answer-input-box"
-            disabled={true}
-            id="1-option-0"
-            name="1-options"
-            onChange={[Function]}
-            type="radio"
-          />
-          <label
-            className="answer-label"
-            htmlFor="1-option-0"
+          <span
+            className="answer-letter-wrapper"
+          >
+            <button
+              aria-label="Choice a:"
+              className="answer-letter"
+              data-test-id="answer-choice-a"
+              disabled={true}
+              onClick={[Function]}
+            >
+              a
+            </button>
+          </span>
+          <div
+            className="answer-answer"
           >
             <span
-              className="answer-letter-wrapper"
-            >
-              <button
-                aria-label="Choice a:"
-                className="answer-letter"
-                data-test-id="answer-choice-a"
-                disabled={true}
-                onClick={[Function]}
-              >
-                a
-              </button>
-            </span>
-            <div
-              className="answer-answer"
-            >
-              <span
-                className="answer-content"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "True",
-                  }
+              className="answer-content"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "True",
                 }
-              />
-            </div>
-          </label>
-        </section>
-      </div>
-      <div
-        className="openstax-answer"
+              }
+            />
+          </div>
+        </label>
+      </section>
+    </div>
+    <div
+      className="openstax-answer"
+    >
+      <section
+        className="answers-answer disabled"
+        role="region"
       >
-        <section
-          className="answers-answer disabled"
-          role="region"
+        <input
+          checked={false}
+          className="answer-input-box"
+          disabled={true}
+          id="1-option-1"
+          name="1-options"
+          onChange={[Function]}
+          type="radio"
+        />
+        <label
+          className="answer-label"
+          htmlFor="1-option-1"
         >
-          <input
-            checked={false}
-            className="answer-input-box"
-            disabled={true}
-            id="1-option-1"
-            name="1-options"
-            onChange={[Function]}
-            type="radio"
-          />
-          <label
-            className="answer-label"
-            htmlFor="1-option-1"
+          <span
+            className="answer-letter-wrapper"
+          >
+            <button
+              aria-label="Choice b:"
+              className="answer-letter"
+              data-test-id="answer-choice-b"
+              disabled={true}
+              onClick={[Function]}
+            >
+              b
+            </button>
+          </span>
+          <div
+            className="answer-answer"
           >
             <span
-              className="answer-letter-wrapper"
-            >
-              <button
-                aria-label="Choice b:"
-                className="answer-letter"
-                data-test-id="answer-choice-b"
-                disabled={true}
-                onClick={[Function]}
-              >
-                b
-              </button>
-            </span>
-            <div
-              className="answer-answer"
-            >
-              <span
-                className="answer-content"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "False",
-                  }
+              className="answer-content"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "False",
                 }
-              />
-            </div>
-          </label>
-        </section>
-      </div>
+              }
+            />
+          </div>
+        </label>
+      </section>
     </div>
   </div>
 </div>
 `;
 
 exports[`Question defaults formats 1`] = `
-<div>
+<div
+  className="sc-bczRLJ jqMCQk openstax-question"
+  data-question-number={1}
+  data-test-id="question"
+>
   <div
-    className="sc-bczRLJ jqMCQk openstax-question"
+    className="question-stem"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "Is this a question?",
+      }
+    }
     data-question-number={1}
-    data-test-id="question"
+  />
+  <div
+    className="answers-table"
   >
     <div
-      className="question-stem"
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "Is this a question?",
-        }
-      }
-      data-question-number={1}
-    />
-    <div
-      className="answers-table"
+      className="openstax-answer"
     >
-      <div
-        className="openstax-answer"
+      <section
+        className="answers-answer disabled"
+        role="region"
       >
-        <section
-          className="answers-answer disabled"
-          role="region"
+        <input
+          checked={false}
+          className="answer-input-box"
+          disabled={true}
+          id="1-option-0"
+          name="1-options"
+          onChange={[Function]}
+          type="radio"
+        />
+        <label
+          className="answer-label"
+          htmlFor="1-option-0"
         >
-          <input
-            checked={false}
-            className="answer-input-box"
-            disabled={true}
-            id="1-option-0"
-            name="1-options"
-            onChange={[Function]}
-            type="radio"
-          />
-          <label
-            className="answer-label"
-            htmlFor="1-option-0"
+          <span
+            className="answer-letter-wrapper"
+          >
+            <button
+              aria-label="Choice a:"
+              className="answer-letter"
+              data-test-id="answer-choice-a"
+              disabled={true}
+              onClick={[Function]}
+            >
+              a
+            </button>
+          </span>
+          <div
+            className="answer-answer"
           >
             <span
-              className="answer-letter-wrapper"
-            >
-              <button
-                aria-label="Choice a:"
-                className="answer-letter"
-                data-test-id="answer-choice-a"
-                disabled={true}
-                onClick={[Function]}
-              >
-                a
-              </button>
-            </span>
-            <div
-              className="answer-answer"
-            >
-              <span
-                className="answer-content"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "True",
-                  }
+              className="answer-content"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "True",
                 }
-              />
-            </div>
-          </label>
-        </section>
-      </div>
-      <div
-        className="openstax-answer"
-      >
-        <section
-          className="answers-answer disabled"
-          role="region"
-        >
-          <input
-            checked={false}
-            className="answer-input-box"
-            disabled={true}
-            id="1-option-1"
-            name="1-options"
-            onChange={[Function]}
-            type="radio"
-          />
-          <label
-            className="answer-label"
-            htmlFor="1-option-1"
-          >
-            <span
-              className="answer-letter-wrapper"
-            >
-              <button
-                aria-label="Choice b:"
-                className="answer-letter"
-                data-test-id="answer-choice-b"
-                disabled={true}
-                onClick={[Function]}
-              >
-                b
-              </button>
-            </span>
-            <div
-              className="answer-answer"
-            >
-              <span
-                className="answer-content"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "False",
-                  }
-                }
-              />
-            </div>
-          </label>
-        </section>
-      </div>
+              }
+            />
+          </div>
+        </label>
+      </section>
     </div>
     <div
-      className="formats-listing"
+      className="openstax-answer"
     >
-      <div
-        className="header"
+      <section
+        className="answers-answer disabled"
+        role="region"
       >
-        Formats:
-      </div>
+        <input
+          checked={false}
+          className="answer-input-box"
+          disabled={true}
+          id="1-option-1"
+          name="1-options"
+          onChange={[Function]}
+          type="radio"
+        />
+        <label
+          className="answer-label"
+          htmlFor="1-option-1"
+        >
+          <span
+            className="answer-letter-wrapper"
+          >
+            <button
+              aria-label="Choice b:"
+              className="answer-letter"
+              data-test-id="answer-choice-b"
+              disabled={true}
+              onClick={[Function]}
+            >
+              b
+            </button>
+          </span>
+          <div
+            className="answer-answer"
+          >
+            <span
+              className="answer-content"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "False",
+                }
+              }
+            />
+          </div>
+        </label>
+      </section>
+    </div>
+  </div>
+  <div
+    className="formats-listing"
+  >
+    <div
+      className="header"
+    >
+      Formats:
     </div>
   </div>
 </div>
 `;
 
 exports[`Question matches snapshot 1`] = `
-<div>
+<div
+  className="sc-bczRLJ jqMCQk openstax-question"
+  data-question-number={1}
+  data-test-id="question"
+>
   <div
-    className="sc-bczRLJ jqMCQk openstax-question"
+    className="question-stem"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "Is this a question?",
+      }
+    }
     data-question-number={1}
-    data-test-id="question"
+  />
+  <div
+    className="answers-table"
   >
     <div
-      className="question-stem"
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "Is this a question?",
-        }
-      }
-      data-question-number={1}
-    />
-    <div
-      className="answers-table"
+      className="openstax-answer"
     >
-      <div
-        className="openstax-answer"
+      <section
+        className="answers-answer disabled"
+        role="region"
       >
-        <section
-          className="answers-answer disabled"
-          role="region"
+        <input
+          checked={false}
+          className="answer-input-box"
+          disabled={true}
+          id="1-option-0"
+          name="1-options"
+          onChange={[Function]}
+          type="radio"
+        />
+        <label
+          className="answer-label"
+          htmlFor="1-option-0"
         >
-          <input
-            checked={false}
-            className="answer-input-box"
-            disabled={true}
-            id="1-option-0"
-            name="1-options"
-            onChange={[Function]}
-            type="radio"
-          />
-          <label
-            className="answer-label"
-            htmlFor="1-option-0"
+          <span
+            className="answer-letter-wrapper"
+          >
+            <button
+              aria-label="Choice a:"
+              className="answer-letter"
+              data-test-id="answer-choice-a"
+              disabled={true}
+              onClick={[Function]}
+            >
+              a
+            </button>
+          </span>
+          <div
+            className="answer-answer"
           >
             <span
-              className="answer-letter-wrapper"
-            >
-              <button
-                aria-label="Choice a:"
-                className="answer-letter"
-                data-test-id="answer-choice-a"
-                disabled={true}
-                onClick={[Function]}
-              >
-                a
-              </button>
-            </span>
-            <div
-              className="answer-answer"
-            >
-              <span
-                className="answer-content"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "True",
-                  }
+              className="answer-content"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "True",
                 }
-              />
-            </div>
-          </label>
-        </section>
-      </div>
-      <div
-        className="openstax-answer"
+              }
+            />
+          </div>
+        </label>
+      </section>
+    </div>
+    <div
+      className="openstax-answer"
+    >
+      <section
+        className="answers-answer disabled"
+        role="region"
       >
-        <section
-          className="answers-answer disabled"
-          role="region"
+        <input
+          checked={false}
+          className="answer-input-box"
+          disabled={true}
+          id="1-option-1"
+          name="1-options"
+          onChange={[Function]}
+          type="radio"
+        />
+        <label
+          className="answer-label"
+          htmlFor="1-option-1"
         >
-          <input
-            checked={false}
-            className="answer-input-box"
-            disabled={true}
-            id="1-option-1"
-            name="1-options"
-            onChange={[Function]}
-            type="radio"
-          />
-          <label
-            className="answer-label"
-            htmlFor="1-option-1"
+          <span
+            className="answer-letter-wrapper"
+          >
+            <button
+              aria-label="Choice b:"
+              className="answer-letter"
+              data-test-id="answer-choice-b"
+              disabled={true}
+              onClick={[Function]}
+            >
+              b
+            </button>
+          </span>
+          <div
+            className="answer-answer"
           >
             <span
-              className="answer-letter-wrapper"
-            >
-              <button
-                aria-label="Choice b:"
-                className="answer-letter"
-                data-test-id="answer-choice-b"
-                disabled={true}
-                onClick={[Function]}
-              >
-                b
-              </button>
-            </span>
-            <div
-              className="answer-answer"
-            >
-              <span
-                className="answer-content"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "False",
-                  }
+              className="answer-content"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "False",
                 }
-              />
-            </div>
-          </label>
-        </section>
-      </div>
+              }
+            />
+          </div>
+        </label>
+      </section>
     </div>
   </div>
 </div>
 `;
 
 exports[`Question renders exercise uid 1`] = `
-<div>
+<div
+  className="sc-bczRLJ jqMCQk openstax-question"
+  data-question-number={1}
+  data-test-id="question"
+>
   <div
-    className="sc-bczRLJ jqMCQk openstax-question"
+    className="question-stem"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "Is this a question?",
+      }
+    }
     data-question-number={1}
-    data-test-id="question"
+  />
+  <div
+    className="answers-table"
   >
     <div
-      className="question-stem"
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "Is this a question?",
-        }
-      }
-      data-question-number={1}
-    />
-    <div
-      className="answers-table"
+      className="openstax-answer"
     >
-      <div
-        className="openstax-answer"
+      <section
+        className="answers-answer disabled"
+        role="region"
       >
-        <section
-          className="answers-answer disabled"
-          role="region"
+        <input
+          checked={false}
+          className="answer-input-box"
+          disabled={true}
+          id="1-option-0"
+          name="1-options"
+          onChange={[Function]}
+          type="radio"
+        />
+        <label
+          className="answer-label"
+          htmlFor="1-option-0"
         >
-          <input
-            checked={false}
-            className="answer-input-box"
-            disabled={true}
-            id="1-option-0"
-            name="1-options"
-            onChange={[Function]}
-            type="radio"
-          />
-          <label
-            className="answer-label"
-            htmlFor="1-option-0"
+          <span
+            className="answer-letter-wrapper"
+          >
+            <button
+              aria-label="Choice a:"
+              className="answer-letter"
+              data-test-id="answer-choice-a"
+              disabled={true}
+              onClick={[Function]}
+            >
+              a
+            </button>
+          </span>
+          <div
+            className="answer-answer"
           >
             <span
-              className="answer-letter-wrapper"
-            >
-              <button
-                aria-label="Choice a:"
-                className="answer-letter"
-                data-test-id="answer-choice-a"
-                disabled={true}
-                onClick={[Function]}
-              >
-                a
-              </button>
-            </span>
-            <div
-              className="answer-answer"
-            >
-              <span
-                className="answer-content"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "True",
-                  }
+              className="answer-content"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "True",
                 }
-              />
-            </div>
-          </label>
-        </section>
-      </div>
-      <div
-        className="openstax-answer"
-      >
-        <section
-          className="answers-answer disabled"
-          role="region"
-        >
-          <input
-            checked={false}
-            className="answer-input-box"
-            disabled={true}
-            id="1-option-1"
-            name="1-options"
-            onChange={[Function]}
-            type="radio"
-          />
-          <label
-            className="answer-label"
-            htmlFor="1-option-1"
-          >
-            <span
-              className="answer-letter-wrapper"
-            >
-              <button
-                aria-label="Choice b:"
-                className="answer-letter"
-                data-test-id="answer-choice-b"
-                disabled={true}
-                onClick={[Function]}
-              >
-                b
-              </button>
-            </span>
-            <div
-              className="answer-answer"
-            >
-              <span
-                className="answer-content"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "False",
-                  }
-                }
-              />
-            </div>
-          </label>
-        </section>
-      </div>
+              }
+            />
+          </div>
+        </label>
+      </section>
     </div>
     <div
-      className="exercise-uid"
+      className="openstax-answer"
     >
-      1@1
+      <section
+        className="answers-answer disabled"
+        role="region"
+      >
+        <input
+          checked={false}
+          className="answer-input-box"
+          disabled={true}
+          id="1-option-1"
+          name="1-options"
+          onChange={[Function]}
+          type="radio"
+        />
+        <label
+          className="answer-label"
+          htmlFor="1-option-1"
+        >
+          <span
+            className="answer-letter-wrapper"
+          >
+            <button
+              aria-label="Choice b:"
+              className="answer-letter"
+              data-test-id="answer-choice-b"
+              disabled={true}
+              onClick={[Function]}
+            >
+              b
+            </button>
+          </span>
+          <div
+            className="answer-answer"
+          >
+            <span
+              className="answer-content"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "False",
+                }
+              }
+            />
+          </div>
+        </label>
+      </section>
     </div>
+  </div>
+  <div
+    className="exercise-uid"
+  >
+    1@1
   </div>
 </div>
 `;
 
 exports[`Question renders formats 1`] = `
-<div>
+<div
+  className="sc-bczRLJ jqMCQk openstax-question"
+  data-question-number={1}
+  data-test-id="question"
+>
   <div
-    className="sc-bczRLJ jqMCQk openstax-question"
+    className="question-stem"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "Is this a question?",
+      }
+    }
     data-question-number={1}
-    data-test-id="question"
+  />
+  <div
+    className="answers-table"
   >
     <div
-      className="question-stem"
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "Is this a question?",
-        }
-      }
-      data-question-number={1}
-    />
-    <div
-      className="answers-table"
+      className="openstax-answer"
     >
-      <div
-        className="openstax-answer"
+      <section
+        className="answers-answer disabled"
+        role="region"
       >
-        <section
-          className="answers-answer disabled"
-          role="region"
+        <input
+          checked={false}
+          className="answer-input-box"
+          disabled={true}
+          id="1-option-0"
+          name="1-options"
+          onChange={[Function]}
+          type="radio"
+        />
+        <label
+          className="answer-label"
+          htmlFor="1-option-0"
         >
-          <input
-            checked={false}
-            className="answer-input-box"
-            disabled={true}
-            id="1-option-0"
-            name="1-options"
-            onChange={[Function]}
-            type="radio"
-          />
-          <label
-            className="answer-label"
-            htmlFor="1-option-0"
+          <span
+            className="answer-letter-wrapper"
+          >
+            <button
+              aria-label="Choice a:"
+              className="answer-letter"
+              data-test-id="answer-choice-a"
+              disabled={true}
+              onClick={[Function]}
+            >
+              a
+            </button>
+          </span>
+          <div
+            className="answer-answer"
           >
             <span
-              className="answer-letter-wrapper"
-            >
-              <button
-                aria-label="Choice a:"
-                className="answer-letter"
-                data-test-id="answer-choice-a"
-                disabled={true}
-                onClick={[Function]}
-              >
-                a
-              </button>
-            </span>
-            <div
-              className="answer-answer"
-            >
-              <span
-                className="answer-content"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "True",
-                  }
+              className="answer-content"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "True",
                 }
-              />
-            </div>
-          </label>
-        </section>
-      </div>
-      <div
-        className="openstax-answer"
-      >
-        <section
-          className="answers-answer disabled"
-          role="region"
-        >
-          <input
-            checked={false}
-            className="answer-input-box"
-            disabled={true}
-            id="1-option-1"
-            name="1-options"
-            onChange={[Function]}
-            type="radio"
-          />
-          <label
-            className="answer-label"
-            htmlFor="1-option-1"
-          >
-            <span
-              className="answer-letter-wrapper"
-            >
-              <button
-                aria-label="Choice b:"
-                className="answer-letter"
-                data-test-id="answer-choice-b"
-                disabled={true}
-                onClick={[Function]}
-              >
-                b
-              </button>
-            </span>
-            <div
-              className="answer-answer"
-            >
-              <span
-                className="answer-content"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "False",
-                  }
-                }
-              />
-            </div>
-          </label>
-        </section>
-      </div>
+              }
+            />
+          </div>
+        </label>
+      </section>
     </div>
     <div
-      className="formats-listing"
+      className="openstax-answer"
     >
-      <div
-        className="header"
+      <section
+        className="answers-answer disabled"
+        role="region"
       >
-        Formats:
-      </div>
-      <span>
-        true-false
-      </span>
+        <input
+          checked={false}
+          className="answer-input-box"
+          disabled={true}
+          id="1-option-1"
+          name="1-options"
+          onChange={[Function]}
+          type="radio"
+        />
+        <label
+          className="answer-label"
+          htmlFor="1-option-1"
+        >
+          <span
+            className="answer-letter-wrapper"
+          >
+            <button
+              aria-label="Choice b:"
+              className="answer-letter"
+              data-test-id="answer-choice-b"
+              disabled={true}
+              onClick={[Function]}
+            >
+              b
+            </button>
+          </span>
+          <div
+            className="answer-answer"
+          >
+            <span
+              className="answer-content"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "False",
+                }
+              }
+            />
+          </div>
+        </label>
+      </section>
     </div>
+  </div>
+  <div
+    className="formats-listing"
+  >
+    <div
+      className="header"
+    >
+      Formats:
+    </div>
+    <span>
+      true-false
+    </span>
   </div>
 </div>
 `;
 
 exports[`Question renders solutions 1`] = `
-<div>
+<div
+  className="sc-bczRLJ jqMCQk openstax-question"
+  data-question-number={1}
+  data-test-id="question"
+>
   <div
-    className="sc-bczRLJ jqMCQk openstax-question"
+    className="question-stem"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "Is this a question?",
+      }
+    }
     data-question-number={1}
-    data-test-id="question"
+  />
+  <div
+    className="answers-table"
   >
     <div
-      className="question-stem"
+      className="openstax-answer"
+    >
+      <section
+        className="answers-answer disabled"
+        role="region"
+      >
+        <input
+          checked={false}
+          className="answer-input-box"
+          disabled={true}
+          id="1-option-0"
+          name="1-options"
+          onChange={[Function]}
+          type="radio"
+        />
+        <label
+          className="answer-label"
+          htmlFor="1-option-0"
+        >
+          <span
+            className="answer-letter-wrapper"
+          >
+            <button
+              aria-label="Choice a:"
+              className="answer-letter"
+              data-test-id="answer-choice-a"
+              disabled={true}
+              onClick={[Function]}
+            >
+              a
+            </button>
+          </span>
+          <div
+            className="answer-answer"
+          >
+            <span
+              className="answer-content"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "True",
+                }
+              }
+            />
+          </div>
+        </label>
+      </section>
+    </div>
+    <div
+      className="openstax-answer"
+    >
+      <section
+        className="answers-answer disabled"
+        role="region"
+      >
+        <input
+          checked={false}
+          className="answer-input-box"
+          disabled={true}
+          id="1-option-1"
+          name="1-options"
+          onChange={[Function]}
+          type="radio"
+        />
+        <label
+          className="answer-label"
+          htmlFor="1-option-1"
+        >
+          <span
+            className="answer-letter-wrapper"
+          >
+            <button
+              aria-label="Choice b:"
+              className="answer-letter"
+              data-test-id="answer-choice-b"
+              disabled={true}
+              onClick={[Function]}
+            >
+              b
+            </button>
+          </span>
+          <div
+            className="answer-answer"
+          >
+            <span
+              className="answer-content"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "False",
+                }
+              }
+            />
+          </div>
+        </label>
+      </section>
+    </div>
+  </div>
+  <div
+    className="detailed-solution"
+  >
+    <div
+      className="header"
+    >
+      Detailed solution:
+    </div>
+    <div
+      className="solution"
       dangerouslySetInnerHTML={
         Object {
-          "__html": "Is this a question?",
+          "__html": "Content HTML",
         }
       }
-      data-question-number={1}
     />
-    <div
-      className="answers-table"
-    >
-      <div
-        className="openstax-answer"
-      >
-        <section
-          className="answers-answer disabled"
-          role="region"
-        >
-          <input
-            checked={false}
-            className="answer-input-box"
-            disabled={true}
-            id="1-option-0"
-            name="1-options"
-            onChange={[Function]}
-            type="radio"
-          />
-          <label
-            className="answer-label"
-            htmlFor="1-option-0"
-          >
-            <span
-              className="answer-letter-wrapper"
-            >
-              <button
-                aria-label="Choice a:"
-                className="answer-letter"
-                data-test-id="answer-choice-a"
-                disabled={true}
-                onClick={[Function]}
-              >
-                a
-              </button>
-            </span>
-            <div
-              className="answer-answer"
-            >
-              <span
-                className="answer-content"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "True",
-                  }
-                }
-              />
-            </div>
-          </label>
-        </section>
-      </div>
-      <div
-        className="openstax-answer"
-      >
-        <section
-          className="answers-answer disabled"
-          role="region"
-        >
-          <input
-            checked={false}
-            className="answer-input-box"
-            disabled={true}
-            id="1-option-1"
-            name="1-options"
-            onChange={[Function]}
-            type="radio"
-          />
-          <label
-            className="answer-label"
-            htmlFor="1-option-1"
-          >
-            <span
-              className="answer-letter-wrapper"
-            >
-              <button
-                aria-label="Choice b:"
-                className="answer-letter"
-                data-test-id="answer-choice-b"
-                disabled={true}
-                onClick={[Function]}
-              >
-                b
-              </button>
-            </span>
-            <div
-              className="answer-answer"
-            >
-              <span
-                className="answer-content"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "False",
-                  }
-                }
-              />
-            </div>
-          </label>
-        </section>
-      </div>
-    </div>
-    <div
-      className="detailed-solution"
-    >
-      <div
-        className="header"
-      >
-        Detailed solution:
-      </div>
-      <div
-        className="solution"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "Content HTML",
-          }
-        }
-      />
-    </div>
   </div>
 </div>
 `;


### PR DESCRIPTION
This ensures all math gets rendered by typesetting all Content components. The previous bugfix will not work for preamble and detailed solution math. A downside to doing it this way is that the render performance might be a little worse - sequentially rendering many containers vs. one.