### PR TITLE
fix not defaulting desktop toolbar to false if omitted

### DIFF
--- a/src/components/ExerciseToolbar.tsx
+++ b/src/components/ExerciseToolbar.tsx
@@ -111,7 +111,7 @@ export const ExerciseToolbar = ({ icons }: { icons?: ExerciseIcons }) => {
   }
   const settings = Object.values(icons);
   const mobile = settings.some(({ location }) => location?.toolbar?.mobile ?? true);
-  const desktop = settings.some(({ location }) => location?.toolbar?.desktop ?? true);
+  const desktop = settings.some(({ location }) => location?.toolbar?.desktop ?? false);
   const topicUrl = icons.topic?.url;
   const errataUrl = icons.errata?.url;
 

--- a/src/components/__snapshots__/Exercise.spec.tsx.snap
+++ b/src/components/__snapshots__/Exercise.spec.tsx.snap
@@ -407,7 +407,7 @@ exports[`Exercise with question state data renders header icons with multiple ch
   className="sc-breuTD uXhmp"
 >
   <div
-    className="sc-ftvSup jsTUAi"
+    className="sc-ftvSup jndYKm"
   >
     <a
       href="https://openstax.org"
@@ -743,7 +743,7 @@ exports[`Exercise with question state data renders header icons with two-step ex
   className="sc-breuTD uXhmp"
 >
   <div
-    className="sc-ftvSup jsTUAi"
+    className="sc-ftvSup jndYKm"
   >
     <a
       href="https://openstax.org"

--- a/src/components/__snapshots__/ExerciseToolbar.spec.tsx.snap
+++ b/src/components/__snapshots__/ExerciseToolbar.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ExerciseToolbar conditionally renders icons 2`] = `
 <div
-  className="sc-bczRLJ dxXYAf"
+  className="sc-bczRLJ hhNxoz"
 >
   <a
     href="https://openstax.org"
@@ -34,7 +34,7 @@ exports[`ExerciseToolbar conditionally renders icons 2`] = `
 
 exports[`ExerciseToolbar conditionally renders icons 3`] = `
 <div
-  className="sc-bczRLJ dxXYAf"
+  className="sc-bczRLJ hhNxoz"
 >
   <a
     href="https://openstax.org"
@@ -66,7 +66,7 @@ exports[`ExerciseToolbar conditionally renders icons 3`] = `
 
 exports[`ExerciseToolbar matches snapshot 1`] = `
 <div
-  className="sc-bczRLJ dxXYAf"
+  className="sc-bczRLJ hhNxoz"
 >
   <a
     href="https://openstax.org"


### PR DESCRIPTION
I forgot to flip this boolean so the default render case in assessments won't require sending any settings.