### PR TITLE
Center progressbar nav and add padding

### DIFF
--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -7,18 +7,19 @@ import { faXmark } from '@fortawesome/free-solid-svg-icons/faXmark';
 
 const ProgressBarWrapper = styled.nav`
   display: flex;
-  justify-content: flex-start;
+  justify-content: center;
   flex-wrap: wrap;
+  gap: 1rem;
   padding: 2rem;
+
   ${breakpoints.mobile`
-    padding: 0;
+    padding: 0.8rem;
   `}
 `;
 
 const StyledItemWrapper = styled.span`
   display: flex;
   align-items: center;
-  margin: 0 1rem 1rem 0;
   position: relative;
 
   &:last-child {

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -13,7 +13,7 @@ const ProgressBarWrapper = styled.nav`
   padding: 2rem;
 
   ${breakpoints.mobile`
-    padding: 0.8rem;
+    padding: 1.6rem 0.8rem;
   `}
 `;
 

--- a/src/components/__snapshots__/ProgressBar.spec.tsx.snap
+++ b/src/components/__snapshots__/ProgressBar.spec.tsx.snap
@@ -3,10 +3,10 @@
 exports[`ProgressBar matches snapshot 1`] = `
 <nav
   aria-label="Breadcrumbs"
-  className="sc-bczRLJ bQqPBP"
+  className="sc-bczRLJ bFkqgV"
 >
   <span
-    className="sc-gsnTZi AyNuQ"
+    className="sc-gsnTZi cxjQPl"
   >
     <button
       aria-current="false"
@@ -38,7 +38,7 @@ exports[`ProgressBar matches snapshot 1`] = `
     </svg>
   </span>
   <span
-    className="sc-gsnTZi AyNuQ"
+    className="sc-gsnTZi cxjQPl"
   >
     <button
       aria-current="false"
@@ -70,7 +70,7 @@ exports[`ProgressBar matches snapshot 1`] = `
     </svg>
   </span>
   <span
-    className="sc-gsnTZi AyNuQ"
+    className="sc-gsnTZi cxjQPl"
   >
     <button
       aria-current="location"
@@ -102,7 +102,7 @@ exports[`ProgressBar matches snapshot 1`] = `
     </svg>
   </span>
   <span
-    className="sc-gsnTZi AyNuQ"
+    className="sc-gsnTZi cxjQPl"
   >
     <button
       aria-current="false"
@@ -114,7 +114,7 @@ exports[`ProgressBar matches snapshot 1`] = `
     </button>
   </span>
   <span
-    className="sc-gsnTZi AyNuQ"
+    className="sc-gsnTZi cxjQPl"
   >
     <button
       aria-current="false"
@@ -126,7 +126,7 @@ exports[`ProgressBar matches snapshot 1`] = `
     </button>
   </span>
   <span
-    className="sc-gsnTZi AyNuQ"
+    className="sc-gsnTZi cxjQPl"
   >
     <button
       aria-current="false"
@@ -138,7 +138,7 @@ exports[`ProgressBar matches snapshot 1`] = `
     </button>
   </span>
   <span
-    className="sc-gsnTZi AyNuQ"
+    className="sc-gsnTZi cxjQPl"
   >
     <button
       aria-current="false"
@@ -166,10 +166,10 @@ exports[`ProgressBar matches snapshot 1`] = `
 exports[`ProgressBar matches snapshot when active step is incomplete 1`] = `
 <nav
   aria-label="Breadcrumbs"
-  className="sc-bczRLJ bQqPBP"
+  className="sc-bczRLJ bFkqgV"
 >
   <span
-    className="sc-gsnTZi AyNuQ"
+    className="sc-gsnTZi cxjQPl"
   >
     <button
       aria-current="false"
@@ -201,7 +201,7 @@ exports[`ProgressBar matches snapshot when active step is incomplete 1`] = `
     </svg>
   </span>
   <span
-    className="sc-gsnTZi AyNuQ"
+    className="sc-gsnTZi cxjQPl"
   >
     <button
       aria-current="false"
@@ -233,7 +233,7 @@ exports[`ProgressBar matches snapshot when active step is incomplete 1`] = `
     </svg>
   </span>
   <span
-    className="sc-gsnTZi AyNuQ"
+    className="sc-gsnTZi cxjQPl"
   >
     <button
       aria-current="false"
@@ -265,7 +265,7 @@ exports[`ProgressBar matches snapshot when active step is incomplete 1`] = `
     </svg>
   </span>
   <span
-    className="sc-gsnTZi AyNuQ"
+    className="sc-gsnTZi cxjQPl"
   >
     <button
       aria-current="location"
@@ -277,7 +277,7 @@ exports[`ProgressBar matches snapshot when active step is incomplete 1`] = `
     </button>
   </span>
   <span
-    className="sc-gsnTZi AyNuQ"
+    className="sc-gsnTZi cxjQPl"
   >
     <button
       aria-current="false"
@@ -289,7 +289,7 @@ exports[`ProgressBar matches snapshot when active step is incomplete 1`] = `
     </button>
   </span>
   <span
-    className="sc-gsnTZi AyNuQ"
+    className="sc-gsnTZi cxjQPl"
   >
     <button
       aria-current="false"
@@ -301,7 +301,7 @@ exports[`ProgressBar matches snapshot when active step is incomplete 1`] = `
     </button>
   </span>
   <span
-    className="sc-gsnTZi AyNuQ"
+    className="sc-gsnTZi cxjQPl"
   >
     <button
       aria-current="false"
@@ -329,10 +329,10 @@ exports[`ProgressBar matches snapshot when active step is incomplete 1`] = `
 exports[`ProgressBar matches snapshot when status step is active 1`] = `
 <nav
   aria-label="Breadcrumbs"
-  className="sc-bczRLJ bQqPBP"
+  className="sc-bczRLJ bFkqgV"
 >
   <span
-    className="sc-gsnTZi AyNuQ"
+    className="sc-gsnTZi cxjQPl"
   >
     <button
       aria-current="false"
@@ -364,7 +364,7 @@ exports[`ProgressBar matches snapshot when status step is active 1`] = `
     </svg>
   </span>
   <span
-    className="sc-gsnTZi AyNuQ"
+    className="sc-gsnTZi cxjQPl"
   >
     <button
       aria-current="false"
@@ -396,7 +396,7 @@ exports[`ProgressBar matches snapshot when status step is active 1`] = `
     </svg>
   </span>
   <span
-    className="sc-gsnTZi AyNuQ"
+    className="sc-gsnTZi cxjQPl"
   >
     <button
       aria-current="false"
@@ -428,7 +428,7 @@ exports[`ProgressBar matches snapshot when status step is active 1`] = `
     </svg>
   </span>
   <span
-    className="sc-gsnTZi AyNuQ"
+    className="sc-gsnTZi cxjQPl"
   >
     <button
       aria-current="false"
@@ -440,7 +440,7 @@ exports[`ProgressBar matches snapshot when status step is active 1`] = `
     </button>
   </span>
   <span
-    className="sc-gsnTZi AyNuQ"
+    className="sc-gsnTZi cxjQPl"
   >
     <button
       aria-current="false"
@@ -452,7 +452,7 @@ exports[`ProgressBar matches snapshot when status step is active 1`] = `
     </button>
   </span>
   <span
-    className="sc-gsnTZi AyNuQ"
+    className="sc-gsnTZi cxjQPl"
   >
     <button
       aria-current="false"
@@ -464,7 +464,7 @@ exports[`ProgressBar matches snapshot when status step is active 1`] = `
     </button>
   </span>
   <span
-    className="sc-gsnTZi AyNuQ"
+    className="sc-gsnTZi cxjQPl"
   >
     <button
       aria-current="location"


### PR DESCRIPTION
The mobile view for the ProgressBar nav needs some room to prevent mistaps, and centering it makes it look better when there aren't many items.

Before:
![image](https://github.com/user-attachments/assets/fdd1af62-8316-423a-b927-17e73d81c02e)

After:
![image](https://github.com/user-attachments/assets/0229585f-a7ff-4b17-b3f7-e09408abf979)
