### PR TITLE
Save and continue when there is no feedback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openstax/assessment-components",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "MIT",
   "source": "./src/index.ts",
   "types": "./dist/src/index.d.ts",

--- a/src/components/Exercise.spec.tsx
+++ b/src/components/Exercise.spec.tsx
@@ -142,6 +142,7 @@ describe('Exercise', () => {
         numberOfQuestions: 1,
         scrollToQuestion: 1,
         hasMultipleAttempts: false,
+        hasFeedback: true,
         onAnswerChange: () => null,
         onAnswerSave: () => null,
         onNextStep: () => null,

--- a/src/components/Exercise.stories.tsx
+++ b/src/components/Exercise.stories.tsx
@@ -130,6 +130,7 @@ const exerciseWithQuestionStatesProps = (): ExerciseWithQuestionStatesProps => {
       apiIsPending: false
     }
   },
+  hasFeedback: true,
 }};
 
 type TextResizerValue = -2 | -1 | 0 | 1 | 2 | 3;
@@ -181,6 +182,34 @@ export const Default = () => {
   )
 };
 
+export const DefaultWithoutFeedback = () => {
+  const [selectedAnswerId, setSelectedAnswerId] = useState<number>(0);
+  const [apiIsPending, setApiIsPending] = useState(false)
+  const [isCompleted, setIsCompleted] = useState(false)
+  const props = exerciseWithQuestionStatesProps();
+  props.hasFeedback = false;
+  props.questionStates['1'].answer_id = selectedAnswerId;
+  props.questionStates['1'].apiIsPending = apiIsPending;
+  props.questionStates['1'].is_completed = isCompleted;
+  props.questionStates['1'].canAnswer = !isCompleted;
+  return (
+    <Exercise
+      {...props}
+      onAnswerChange={(a: Omit<Answer, 'id'> & { id: number, question_id: number }) => {
+        setSelectedAnswerId(a.id)
+      }}
+      onAnswerSave={() => {
+        setApiIsPending(true);
+        setTimeout(() => {
+          setApiIsPending(false)
+          setIsCompleted(true)
+        }, 1000)
+      }}
+      onNextStep={(idx) => console.log(`Next step: ${idx}`)}
+    />
+  )
+};
+
 export const DeprecatedStepData = () => <Exercise {...exerciseWithStepDataProps} />;
 
 export const CompleteWithFeedback = () => {
@@ -205,6 +234,34 @@ export const CompleteWithFeedback = () => {
         apiIsPending: false
       }
     }
+  };
+
+  return <TextResizerProvider><Exercise {...props} /></TextResizerProvider>;
+};
+
+export const CompleteWithoutFeedback = () => {
+  const props: ExerciseWithQuestionStatesProps = {
+    ...exerciseWithQuestionStatesProps(),
+
+    questionStates: {
+      '1': {
+        available_points: '1.0',
+        is_completed: true,
+        answer_id_order: ['1', '2'],
+        answer_id: 1,
+        free_response: 'Free response',
+        feedback_html: '',
+        correct_answer_id: '',
+        correct_answer_feedback_html: '',
+        attempts_remaining: 0,
+        attempt_number: 1,
+        incorrectAnswerId: 0,
+        canAnswer: false,
+        needsSaved: false,
+        apiIsPending: false
+      }
+    },
+    hasFeedback: false,
   };
 
   return <TextResizerProvider><Exercise {...props} /></TextResizerProvider>;

--- a/src/components/Exercise.tsx
+++ b/src/components/Exercise.tsx
@@ -138,6 +138,7 @@ export interface ExerciseBaseProps {
    * - A topic icon linking to the relevant textbook location
    */
   exerciseIcons?: ExerciseIcons;
+  hasFeedback?: boolean;
 }
 
 export interface ExerciseWithStepDataProps extends ExerciseBaseProps {

--- a/src/components/ExerciseQuestion.spec.tsx
+++ b/src/components/ExerciseQuestion.spec.tsx
@@ -50,6 +50,7 @@ describe('ExerciseQuestion', () => {
       displaySolution: false,
       available_points: '1.0',
       exercise_uid: '',
+      hasFeedback: true,
     }
   });
 
@@ -125,6 +126,21 @@ describe('ExerciseQuestion', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('renders Submit & continue button', () => {
+    const tree = renderer.create(
+      <ExerciseQuestion {...props}
+        choicesEnabled={true}
+        incorrectAnswerId='2'
+        canAnswer={true}
+        needsSaved={true}
+        answer_id='1'
+        canUpdateCurrentStep={false}
+        hasFeedback={false}
+      />
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it('renders continue button (unused?)', () => {
     const tree = renderer.create(
       <ExerciseQuestion {...props}
@@ -193,6 +209,29 @@ describe('ExerciseQuestion', () => {
     );
     renderer.act(() => {
       tree.root.findByType(NextButton).props.onClick();
+    });
+
+    expect(mockFn).toHaveBeenCalledWith(0);
+  });
+
+  it('passes question index on submit button click when there is not feedback', () => {
+    const mockFn = jest.fn();
+
+    // This combination of props should never happen: `is_completed` should not 
+    // be true at the same time as `needsSaved`. This combination allows the 
+    // test to work correctly without simulating waiting for api calls
+    const tree = renderer.create(
+      <ExerciseQuestion
+        {...props}
+        needsSaved={true}
+        canAnswer={true}
+        hasFeedback={false}
+        is_completed={true}
+        onNextStep={mockFn}
+      />
+    );
+    renderer.act(() => {
+      tree.root.findByType(SaveButton).props.onClick();
     });
 
     expect(mockFn).toHaveBeenCalledWith(0);

--- a/src/components/ExerciseQuestion.stories.tsx
+++ b/src/components/ExerciseQuestion.stories.tsx
@@ -51,7 +51,8 @@ const props = {
   needsSaved: true,
   canUpdateCurrentStep: true,
   attempt_number: 0,
-  apiIsPending: false
+  apiIsPending: false,
+  hasFeedback: false
 };
 
 export const Default = () => <ExerciseQuestion {...props} />;

--- a/src/components/__snapshots__/ExerciseQuestion.spec.tsx.snap
+++ b/src/components/__snapshots__/ExerciseQuestion.spec.tsx.snap
@@ -470,6 +470,165 @@ exports[`ExerciseQuestion renders Save button 1`] = `
 </div>
 `;
 
+exports[`ExerciseQuestion renders Submit & continue button 1`] = `
+<div
+  data-test-id="student-exercise-question"
+>
+  <div
+    className="sc-dkzDqf cYzaBK openstax-question step-card-body has-incorrect-answer"
+    data-question-number={1}
+    data-test-id="question"
+  >
+    <div
+      className="question-stem"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "Is this a question?",
+        }
+      }
+      data-question-number={1}
+    />
+    <div
+      className="answers-table"
+    >
+      <div
+        className="openstax-answer"
+      >
+        <section
+          className="answers-answer answer-selected"
+        >
+          <input
+            checked={true}
+            className="answer-input-box"
+            disabled={false}
+            id="1-option-0"
+            name="1-options"
+            onChange={[Function]}
+            type="radio"
+          />
+          <label
+            className="answer-label"
+            htmlFor="1-option-0"
+          >
+            <span
+              className="answer-letter-wrapper"
+            >
+              <button
+                aria-label="Selected Choice A:"
+                className="answer-letter"
+                data-test-id="answer-choice-A"
+                disabled={false}
+                onClick={[Function]}
+              >
+                A
+              </button>
+            </span>
+            <div
+              className="answer-answer"
+            >
+              <span
+                className="answer-content"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "True",
+                  }
+                }
+              />
+            </div>
+          </label>
+        </section>
+      </div>
+      <div
+        className="openstax-answer"
+      >
+        <section
+          className="answers-answer answer-incorrect"
+        >
+          <input
+            checked={false}
+            className="answer-input-box"
+            disabled={false}
+            id="1-option-1"
+            name="1-options"
+            onChange={[Function]}
+            type="radio"
+          />
+          <label
+            className="answer-label"
+            htmlFor="1-option-1"
+          >
+            <span
+              className="answer-letter-wrapper"
+            >
+              <button
+                aria-label="Choice B:"
+                className="answer-letter"
+                data-test-id="answer-choice-B"
+                disabled={true}
+                onClick={[Function]}
+              >
+                B
+              </button>
+            </span>
+            <div
+              className="answer-answer"
+            >
+              <div
+                className="sc-gsnTZi jsjSLp"
+              >
+                Incorrect
+                 Answer
+              </div>
+              <span
+                className="answer-content"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "False",
+                  }
+                }
+              />
+            </div>
+          </label>
+        </section>
+      </div>
+    </div>
+  </div>
+  <div
+    className="sc-hKMtZM eTQwo step-card-footer"
+  >
+    <div
+      className="step-card-footer-inner"
+    >
+      <div
+        className="points"
+        role="status"
+      >
+        <strong>
+          Points: 
+          1.0
+        </strong>
+        <span
+          className="attempts-left"
+        />
+        
+      </div>
+      <div
+        className="controls"
+      >
+        <button
+          className="sc-bczRLJ fLTvYy"
+          data-test-id="submit-answer-btn"
+          disabled={false}
+          onClick={[Function]}
+        >
+          Submit & continue
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`ExerciseQuestion renders all attempts remaining 1`] = `
 <div
   data-test-id="student-exercise-question"


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-173

Why do it this way?

`onAnswerSave` is non-blocking and non-awaitable. Consequently, calling `onAnswerSave` in the onClick of the submit button does not work because this will advance to the next question before the current one is finished saving.

We know that the api is done saving when `is_completed` becomes true.

When `hasFeedback` is falsey and the submit button is clicked, `shouldContinue` is set to `true`.

**Assumption**:
If both `shouldContinue` and `is_completed` are true, then the answer has been submitted and saved and it is okay to advance.