### PR TITLE
Core 422 419 answer choice accessibility

### DIFF
--- a/src/components/Answer.tsx
+++ b/src/components/Answer.tsx
@@ -45,6 +45,7 @@ export interface AnswerProps {
   contentRenderer?: JSX.Element;
   show_all_feedback?: boolean;
   tableFeedbackEnabled?: boolean;
+  feedbackId?: string;
 }
 
 export const Answer = (props: AnswerProps) => {
@@ -63,6 +64,7 @@ export const Answer = (props: AnswerProps) => {
     contentRenderer,
     show_all_feedback,
     tableFeedbackEnabled,
+    feedbackId,
   } = props;
 
   let body, feedback, selectedCount;
@@ -99,7 +101,7 @@ export const Answer = (props: AnswerProps) => {
   }
   ariaLabel += ':';
 
-  let onChangeAnswer: AnswerProps['onChangeAnswer'], radioBox;
+  let onChangeAnswer: AnswerProps['onChangeAnswer'];
 
   const onChange = () => onChangeAnswer && onChangeAnswer(answer);
 
@@ -108,20 +110,6 @@ export const Answer = (props: AnswerProps) => {
     && (type !== 'teacher-preview')
     && (type !== 'student-mpp')) {
     ({ onChangeAnswer } = props);
-  }
-
-  if (onChangeAnswer) {
-    radioBox = (
-      <input
-        type="radio"
-        className="answer-input-box"
-        checked={isChecked}
-        id={`${qid}-option-${iter}`}
-        name={`${qid}-options`}
-        onChange={onChange}
-        disabled={disabled}
-      />
-    );
   }
 
   if (show_all_feedback && answer.feedback_html && !tableFeedbackEnabled) {
@@ -166,21 +154,27 @@ export const Answer = (props: AnswerProps) => {
       <>
         {type === 'teacher-preview' && correctIncorrectIcon}
         {selectedCount}
-        {radioBox}
+        <input
+          type="radio"
+          className="answer-input-box"
+          checked={isChecked}
+          aria-checked={isChecked}
+          id={`${qid}-option-${iter}`}
+          name={`${qid}-options`}
+          onChange={onChange}
+          disabled={disabled || !onChangeAnswer}
+          aria-details={feedbackId}
+        />
         <label
           onKeyPress={onKeyPress}
           htmlFor={`${qid}-option-${iter}`}
           className="answer-label">
-          <span className="answer-letter-wrapper">
-            <button
-              onClick={onChange}
-              aria-label={ariaLabel}
-              className="answer-letter"
-              disabled={disabled || isIncorrect}
-              data-test-id={`answer-choice-${ALPHABET[iter]}`}
-            >
-              {ALPHABET[iter]}
-            </button>
+          <span
+            className="answer-letter-wrapper"
+            aria-label={ariaLabel}
+            data-answer-choice={ALPHABET[iter]}
+            data-test-id={`answer-choice-${ALPHABET[iter]}`}
+          >
           </span>
           <div className="answer-answer">
             <AnswerIndicator isCorrect={isCorrect} isIncorrect={isIncorrect} />

--- a/src/components/Answer.tsx
+++ b/src/components/Answer.tsx
@@ -80,9 +80,10 @@ export const Answer = (props: AnswerProps) => {
   // incorrectAnswerId will be empty.
   const isPreviousResponse = answerId === undefined && (!incorrectAnswerId && isCorrect || isIncorrect);
 
+  const isSelected = isChecked || isPreviousResponse;
   const classes = cn('answers-answer', {
     'disabled': disabled,
-    'answer-selected': isChecked || isPreviousResponse,
+    'answer-selected': isSelected,
     'answer-correct': isCorrect && type !== 'student-mpp',
     'answer-incorrect': incorrectAnswerId && isAnswerIncorrect(answer, incorrectAnswerId),
   });
@@ -93,7 +94,7 @@ export const Answer = (props: AnswerProps) => {
     </div>
   );
 
-  let ariaLabel = `${isChecked ? 'Selected ' : ''}Choice ${ALPHABET[iter]}`;
+  let ariaLabel = `${isSelected ? 'Selected ' : ''}Choice ${ALPHABET[iter]}`;
   ariaLabel += ':';
 
   let onChangeAnswer: AnswerProps['onChangeAnswer'];
@@ -152,8 +153,8 @@ export const Answer = (props: AnswerProps) => {
         <input
           type="radio"
           className="answer-input-box"
-          checked={isChecked}
-          aria-checked={isChecked}
+          checked={isSelected}
+          aria-checked={isSelected}
           id={`${qid}-option-${iter}`}
           name={`${qid}-options`}
           onChange={onChange}

--- a/src/components/Answer.tsx
+++ b/src/components/Answer.tsx
@@ -94,11 +94,6 @@ export const Answer = (props: AnswerProps) => {
   );
 
   let ariaLabel = `${isChecked ? 'Selected ' : ''}Choice ${ALPHABET[iter]}`;
-  // somewhat misleading - this means that there is a correct answer,
-  // not necessarily that this answer is correct
-  if (hasCorrectAnswer) {
-    ariaLabel += `(${isCorrect ? 'Correct' : 'Incorrect'} Answer)`;
-  }
   ariaLabel += ':';
 
   let onChangeAnswer: AnswerProps['onChangeAnswer'];

--- a/src/components/AnswersTable.tsx
+++ b/src/components/AnswersTable.tsx
@@ -37,7 +37,7 @@ export const AnswersTable = (props: AnswersTableProps) => {
 
   const { id } = question;
 
-  const feedback: { index: number, html: string }[] = [];
+  const feedback: { index: number, html: string, id: string }[] = [];
 
   const sortedAnswersByIdOrder = (idOrder: ID[]) => {
     const { answers } = question;
@@ -69,34 +69,38 @@ export const AnswersTable = (props: AnswersTableProps) => {
           question_id: typeof question.id === 'string' ? parseInt(question.id, 10) : question.id
          },
       iter: i,
-      key: `${questionAnswerProps.qid}-option-${i}`
+      key: `${questionAnswerProps.qid}-option-${i}`,
     };
     const answerProps = Object.assign({}, additionalProps, questionAnswerProps);
+    const feedbackId = `feedback-${questionAnswerProps.qid}-${i}`
+    let hasFeedback = true;
 
     if (show_all_feedback && answer.feedback_html && tableFeedbackEnabled) {
-      feedback.push({ index: i, html: answer.feedback_html })
+      feedback.push({ index: i, html: answer.feedback_html, id: feedbackId })
     } else if (answer.id === incorrectAnswerId && feedback_html) {
-      feedback.push({ index: i, html: feedback_html })
+      feedback.push({ index: i, html: feedback_html, id: feedbackId })
     } else if (answer.id === correct_answer_id && correct_answer_feedback_html) {
-      feedback.push({ index: i, html: correct_answer_feedback_html })
+      feedback.push({ index: i, html: correct_answer_feedback_html, id: feedbackId })
+    } else {
+      hasFeedback = false;
     }
 
     return (
-      <Answer {...answerProps} />
+      <Answer feedbackId={hasFeedback ? feedbackId : undefined} {...answerProps} />
     );
   });
 
   feedback.forEach((item, i) => {
     const spliceIndex = item.index + i + 1;
     answersHtml.splice(spliceIndex, 0, (
-      <Feedback key={spliceIndex} contentRenderer={props.contentRenderer}>
+      <Feedback id={item.id} key={spliceIndex} contentRenderer={props.contentRenderer}>
         {item.html}
       </Feedback>
     ));
   });
 
   return (
-    <div className="answers-table">
+    <div role="radiogroup" aria-label="Answer choices" className="answers-table">
       {instructions}
       {answersHtml}
     </div>

--- a/src/components/ExerciseQuestion.stories.tsx
+++ b/src/components/ExerciseQuestion.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { ExerciseQuestion } from './ExerciseQuestion';
 
 const props = {
@@ -55,7 +56,10 @@ const props = {
   hasFeedback: false
 };
 
-export const Default = () => <ExerciseQuestion {...props} />;
+export const Default = () => {
+  const [answerId, setAnswerId] = React.useState('')
+  return <ExerciseQuestion {...props} answer_id={answerId} onAnswerChange={({ id }) => { console.log(id); setAnswerId(id) }} />
+};
 export const FreeResponseEntered = () =>
   <ExerciseQuestion {...props}
     free_response="In this free response, I will..."

--- a/src/components/Feedback.tsx
+++ b/src/components/Feedback.tsx
@@ -6,6 +6,7 @@ interface FeedbackProps {
   children: string;
   className?: string;
   contentRenderer?: JSX.Element;
+  id: string
 }
 
 const SimpleFeedback = (props: Pick<FeedbackProps, 'children' | 'className' | 'contentRenderer'>) => (
@@ -18,12 +19,12 @@ const SimpleFeedback = (props: Pick<FeedbackProps, 'children' | 'className' | 'c
   </aside>
 );
 
-const Feedback = (props: FeedbackProps) => {
+const Feedback = ({ id, ...props }: FeedbackProps) => {
   const position = props.position || 'bottom';
   const wrapperClasses = classnames('question-feedback', position);
 
   return (
-    <aside className={wrapperClasses}>
+    <aside id={id} className={wrapperClasses}>
       <div className="arrow" aria-label="Answer Feedback" />
       <SimpleFeedback {...props}>
         {props.children}

--- a/src/components/Question.tsx
+++ b/src/components/Question.tsx
@@ -101,7 +101,8 @@ const StyledQuestion = styled.div`
       }
     }
 
-    .answer-letter {
+    .answer-letter-wrapper::before {
+      content: attr(data-answer-choice);
       text-align: center;
       padding: 0;
       font-size: 1.6rem;
@@ -126,15 +127,32 @@ const StyledQuestion = styled.div`
       }
     }
 
+    // hide the radio button in all cases
+    .answer-input-box {
+      clip: rect(0px, 0px, 0px, 0px);
+      clip-path: inset(50%);
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+    }
+
     // a selected answer
     &:not(.has-correct-answer) {
       .answer-input-box {
-        display: none;
-
         &:checked {
           + .answer-label,
           + .answer-label:hover {
             ${mixins.answerChecked()};
+          }
+        }
+
+        &:focus-visible {
+          + .answer-label .answer-letter-wrapper::before {
+            outline-style: solid;
+            outline-width: 2px;
+            outline-offset: 2px;
+            outline-color: ${colors.answer.checked};
           }
         }
       }

--- a/src/components/__snapshots__/Answer.spec.tsx.snap
+++ b/src/components/__snapshots__/Answer.spec.tsx.snap
@@ -8,6 +8,7 @@ exports[`Answer matches snapshot 1`] = `
     className="answers-answer"
   >
     <input
+      aria-checked={false}
       checked={false}
       className="answer-input-box"
       disabled={false}
@@ -22,18 +23,11 @@ exports[`Answer matches snapshot 1`] = `
       onKeyPress={[Function]}
     >
       <span
+        aria-label="Choice B:"
         className="answer-letter-wrapper"
-      >
-        <button
-          aria-label="Choice B:"
-          className="answer-letter"
-          data-test-id="answer-choice-B"
-          disabled={false}
-          onClick={[Function]}
-        >
-          B
-        </button>
-      </span>
+        data-answer-choice="B"
+        data-test-id="answer-choice-B"
+      />
       <div
         className="answer-answer"
       >
@@ -64,6 +58,7 @@ exports[`Answer renders a checked answer 1`] = `
     className="answers-answer answer-selected"
   >
     <input
+      aria-checked={true}
       checked={true}
       className="answer-input-box"
       disabled={false}
@@ -78,18 +73,11 @@ exports[`Answer renders a checked answer 1`] = `
       onKeyPress={[Function]}
     >
       <span
+        aria-label="Selected Choice B:"
         className="answer-letter-wrapper"
-      >
-        <button
-          aria-label="Selected Choice B:"
-          className="answer-letter"
-          data-test-id="answer-choice-B"
-          disabled={false}
-          onClick={[Function]}
-        >
-          B
-        </button>
-      </span>
+        data-answer-choice="B"
+        data-test-id="answer-choice-B"
+      />
       <div
         className="answer-answer"
       >
@@ -119,24 +107,27 @@ exports[`Answer renders a correct answer 1`] = `
   <section
     className="answers-answer disabled answer-correct"
   >
+    <input
+      aria-checked={false}
+      checked={false}
+      className="answer-input-box"
+      disabled={true}
+      id="1-option-1"
+      name="1-options"
+      onChange={[Function]}
+      type="radio"
+    />
     <label
       className="answer-label"
       htmlFor="1-option-1"
       onKeyPress={[Function]}
     >
       <span
+        aria-label="Choice B:"
         className="answer-letter-wrapper"
-      >
-        <button
-          aria-label="Choice B(Correct Answer):"
-          className="answer-letter"
-          data-test-id="answer-choice-B"
-          disabled={true}
-          onClick={[Function]}
-        >
-          B
-        </button>
-      </span>
+        data-answer-choice="B"
+        data-test-id="answer-choice-B"
+      />
       <div
         className="answer-answer"
       >
@@ -172,24 +163,27 @@ exports[`Answer renders an incorrect answer 1`] = `
   <section
     className="answers-answer answer-incorrect"
   >
+    <input
+      aria-checked={false}
+      checked={false}
+      className="answer-input-box"
+      disabled={true}
+      id="1-option-1"
+      name="1-options"
+      onChange={[Function]}
+      type="radio"
+    />
     <label
       className="answer-label"
       htmlFor="1-option-1"
       onKeyPress={[Function]}
     >
       <span
+        aria-label="Choice B:"
         className="answer-letter-wrapper"
-      >
-        <button
-          aria-label="Choice B(Incorrect Answer):"
-          className="answer-letter"
-          data-test-id="answer-choice-B"
-          disabled={true}
-          onClick={[Function]}
-        >
-          B
-        </button>
-      </span>
+        data-answer-choice="B"
+        data-test-id="answer-choice-B"
+      />
       <div
         className="answer-answer"
       >
@@ -226,6 +220,7 @@ exports[`Answer renders feedback 1`] = `
     className="answers-answer"
   >
     <input
+      aria-checked={false}
       checked={false}
       className="answer-input-box"
       disabled={false}
@@ -240,18 +235,11 @@ exports[`Answer renders feedback 1`] = `
       onKeyPress={[Function]}
     >
       <span
+        aria-label="Choice B:"
         className="answer-letter-wrapper"
-      >
-        <button
-          aria-label="Choice B:"
-          className="answer-letter"
-          data-test-id="answer-choice-B"
-          disabled={false}
-          onClick={[Function]}
-        >
-          B
-        </button>
-      </span>
+        data-answer-choice="B"
+        data-test-id="answer-choice-B"
+      />
       <div
         className="answer-answer"
       >
@@ -298,24 +286,27 @@ exports[`Answer renders teacher preview 1`] = `
         Iconic
       </span>
     </div>
+    <input
+      aria-checked={false}
+      checked={false}
+      className="answer-input-box"
+      disabled={true}
+      id="1-option-1"
+      name="1-options"
+      onChange={[Function]}
+      type="radio"
+    />
     <label
       className="answer-label"
       htmlFor="1-option-1"
       onKeyPress={[Function]}
     >
       <span
+        aria-label="Choice B:"
         className="answer-letter-wrapper"
-      >
-        <button
-          aria-label="Choice B:"
-          className="answer-letter"
-          data-test-id="answer-choice-B"
-          disabled={false}
-          onClick={[Function]}
-        >
-          B
-        </button>
-      </span>
+        data-answer-choice="B"
+        data-test-id="answer-choice-B"
+      />
       <div
         className="answer-answer"
       >
@@ -399,6 +390,7 @@ exports[`Answer renders with a custom renderer if set 1`] = `
     className="answers-answer"
   >
     <input
+      aria-checked={false}
       checked={false}
       className="answer-input-box"
       disabled={false}
@@ -413,18 +405,11 @@ exports[`Answer renders with a custom renderer if set 1`] = `
       onKeyPress={[Function]}
     >
       <span
+        aria-label="Choice B:"
         className="answer-letter-wrapper"
-      >
-        <button
-          aria-label="Choice B:"
-          className="answer-letter"
-          data-test-id="answer-choice-B"
-          disabled={false}
-          onClick={[Function]}
-        >
-          B
-        </button>
-      </span>
+        data-answer-choice="B"
+        data-test-id="answer-choice-B"
+      />
       <div
         className="answer-answer"
       >

--- a/src/components/__snapshots__/AnswersTable.spec.tsx.snap
+++ b/src/components/__snapshots__/AnswersTable.spec.tsx.snap
@@ -2,7 +2,9 @@
 
 exports[`AnswersTable matches tutor teacher-preview snapshot 1`] = `
 <div
+  aria-label="Answer choices"
   className="answers-table"
+  role="radiogroup"
 >
   <div
     className="openstax-answer"
@@ -13,24 +15,27 @@ exports[`AnswersTable matches tutor teacher-preview snapshot 1`] = `
       <div
         className="correct-incorrect"
       />
+      <input
+        aria-checked={false}
+        checked={false}
+        className="answer-input-box"
+        disabled={true}
+        id="1-option-0"
+        name="1-options"
+        onChange={[Function]}
+        type="radio"
+      />
       <label
         className="answer-label"
         htmlFor="1-option-0"
         onKeyPress={[Function]}
       >
         <span
+          aria-label="Choice A:"
           className="answer-letter-wrapper"
-        >
-          <button
-            aria-label="Choice A:"
-            className="answer-letter"
-            data-test-id="answer-choice-A"
-            disabled={true}
-            onClick={[Function]}
-          >
-            A
-          </button>
-        </span>
+          data-answer-choice="A"
+          data-test-id="answer-choice-A"
+        />
         <div
           className="answer-answer"
         >
@@ -60,24 +65,27 @@ exports[`AnswersTable matches tutor teacher-preview snapshot 1`] = `
       <div
         className="correct-incorrect"
       />
+      <input
+        aria-checked={false}
+        checked={false}
+        className="answer-input-box"
+        disabled={true}
+        id="1-option-1"
+        name="1-options"
+        onChange={[Function]}
+        type="radio"
+      />
       <label
         className="answer-label"
         htmlFor="1-option-1"
         onKeyPress={[Function]}
       >
         <span
+          aria-label="Choice B:"
           className="answer-letter-wrapper"
-        >
-          <button
-            aria-label="Choice B:"
-            className="answer-letter"
-            data-test-id="answer-choice-B"
-            disabled={true}
-            onClick={[Function]}
-          >
-            B
-          </button>
-        </span>
+          data-answer-choice="B"
+          data-test-id="answer-choice-B"
+        />
         <div
           className="answer-answer"
         >
@@ -103,7 +111,9 @@ exports[`AnswersTable matches tutor teacher-preview snapshot 1`] = `
 
 exports[`AnswersTable renders all feedback 1`] = `
 <div
+  aria-label="Answer choices"
   className="answers-table"
+  role="radiogroup"
 >
   <div
     className="openstax-answer"
@@ -112,6 +122,8 @@ exports[`AnswersTable renders all feedback 1`] = `
       className="answers-answer disabled answer-selected answer-incorrect"
     >
       <input
+        aria-checked={true}
+        aria-details="feedback-1-0"
         checked={true}
         className="answer-input-box"
         disabled={true}
@@ -125,18 +137,11 @@ exports[`AnswersTable renders all feedback 1`] = `
         htmlFor="1-option-0"
       >
         <span
+          aria-label="Selected Choice A:"
           className="answer-letter-wrapper"
-        >
-          <button
-            aria-label="Selected Choice A:"
-            className="answer-letter"
-            data-test-id="answer-choice-A"
-            disabled={true}
-            onClick={[Function]}
-          >
-            A
-          </button>
-        </span>
+          data-answer-choice="A"
+          data-test-id="answer-choice-A"
+        />
         <div
           className="answer-answer"
         >
@@ -160,6 +165,7 @@ exports[`AnswersTable renders all feedback 1`] = `
   </div>
   <aside
     className="question-feedback bottom"
+    id="feedback-1-0"
   >
     <div
       aria-label="Answer Feedback"
@@ -183,6 +189,8 @@ exports[`AnswersTable renders all feedback 1`] = `
       className="answers-answer disabled answer-correct"
     >
       <input
+        aria-checked={false}
+        aria-details="feedback-1-1"
         checked={false}
         className="answer-input-box"
         disabled={true}
@@ -196,18 +204,11 @@ exports[`AnswersTable renders all feedback 1`] = `
         htmlFor="1-option-1"
       >
         <span
+          aria-label="Choice B:"
           className="answer-letter-wrapper"
-        >
-          <button
-            aria-label="Choice B:"
-            className="answer-letter"
-            data-test-id="answer-choice-B"
-            disabled={true}
-            onClick={[Function]}
-          >
-            B
-          </button>
-        </span>
+          data-answer-choice="B"
+          data-test-id="answer-choice-B"
+        />
         <div
           className="answer-answer"
         >
@@ -231,6 +232,7 @@ exports[`AnswersTable renders all feedback 1`] = `
   </div>
   <aside
     className="question-feedback bottom"
+    id="feedback-1-1"
   >
     <div
       aria-label="Answer Feedback"
@@ -252,7 +254,9 @@ exports[`AnswersTable renders all feedback 1`] = `
 
 exports[`AnswersTable renders correct answer feedback 1`] = `
 <div
+  aria-label="Answer choices"
   className="answers-table"
+  role="radiogroup"
 >
   <div
     className="openstax-answer"
@@ -260,23 +264,27 @@ exports[`AnswersTable renders correct answer feedback 1`] = `
     <section
       className="answers-answer disabled answer-selected answer-correct"
     >
+      <input
+        aria-checked={true}
+        aria-details="feedback-1-0"
+        checked={true}
+        className="answer-input-box"
+        disabled={true}
+        id="1-option-0"
+        name="1-options"
+        onChange={[Function]}
+        type="radio"
+      />
       <label
         className="answer-label"
         htmlFor="1-option-0"
       >
         <span
+          aria-label="Selected Choice A:"
           className="answer-letter-wrapper"
-        >
-          <button
-            aria-label="Selected Choice A(Correct Answer):"
-            className="answer-letter"
-            data-test-id="answer-choice-A"
-            disabled={true}
-            onClick={[Function]}
-          >
-            A
-          </button>
-        </span>
+          data-answer-choice="A"
+          data-test-id="answer-choice-A"
+        />
         <div
           className="answer-answer"
         >
@@ -300,6 +308,7 @@ exports[`AnswersTable renders correct answer feedback 1`] = `
   </div>
   <aside
     className="question-feedback bottom"
+    id="feedback-1-0"
   >
     <div
       aria-label="Answer Feedback"
@@ -322,23 +331,26 @@ exports[`AnswersTable renders correct answer feedback 1`] = `
     <section
       className="answers-answer disabled"
     >
+      <input
+        aria-checked={false}
+        checked={false}
+        className="answer-input-box"
+        disabled={true}
+        id="1-option-1"
+        name="1-options"
+        onChange={[Function]}
+        type="radio"
+      />
       <label
         className="answer-label"
         htmlFor="1-option-1"
       >
         <span
+          aria-label="Choice B:"
           className="answer-letter-wrapper"
-        >
-          <button
-            aria-label="Choice B(Incorrect Answer):"
-            className="answer-letter"
-            data-test-id="answer-choice-B"
-            disabled={true}
-            onClick={[Function]}
-          >
-            B
-          </button>
-        </span>
+          data-answer-choice="B"
+          data-test-id="answer-choice-B"
+        />
         <div
           className="answer-answer"
         >
@@ -359,7 +371,9 @@ exports[`AnswersTable renders correct answer feedback 1`] = `
 
 exports[`AnswersTable renders incorrect answer feedback 1`] = `
 <div
+  aria-label="Answer choices"
   className="answers-table"
+  role="radiogroup"
 >
   <div
     className="openstax-answer"
@@ -368,6 +382,8 @@ exports[`AnswersTable renders incorrect answer feedback 1`] = `
       className="answers-answer disabled answer-selected answer-incorrect"
     >
       <input
+        aria-checked={true}
+        aria-details="feedback-1-0"
         checked={true}
         className="answer-input-box"
         disabled={true}
@@ -381,18 +397,11 @@ exports[`AnswersTable renders incorrect answer feedback 1`] = `
         htmlFor="1-option-0"
       >
         <span
+          aria-label="Selected Choice A:"
           className="answer-letter-wrapper"
-        >
-          <button
-            aria-label="Selected Choice A:"
-            className="answer-letter"
-            data-test-id="answer-choice-A"
-            disabled={true}
-            onClick={[Function]}
-          >
-            A
-          </button>
-        </span>
+          data-answer-choice="A"
+          data-test-id="answer-choice-A"
+        />
         <div
           className="answer-answer"
         >
@@ -416,6 +425,7 @@ exports[`AnswersTable renders incorrect answer feedback 1`] = `
   </div>
   <aside
     className="question-feedback bottom"
+    id="feedback-1-0"
   >
     <div
       aria-label="Answer Feedback"
@@ -439,6 +449,7 @@ exports[`AnswersTable renders incorrect answer feedback 1`] = `
       className="answers-answer disabled answer-correct"
     >
       <input
+        aria-checked={false}
         checked={false}
         className="answer-input-box"
         disabled={true}
@@ -452,18 +463,11 @@ exports[`AnswersTable renders incorrect answer feedback 1`] = `
         htmlFor="1-option-1"
       >
         <span
+          aria-label="Choice B:"
           className="answer-letter-wrapper"
-        >
-          <button
-            aria-label="Choice B:"
-            className="answer-letter"
-            data-test-id="answer-choice-B"
-            disabled={true}
-            onClick={[Function]}
-          >
-            B
-          </button>
-        </span>
+          data-answer-choice="B"
+          data-test-id="answer-choice-B"
+        />
         <div
           className="answer-answer"
         >
@@ -490,7 +494,9 @@ exports[`AnswersTable renders incorrect answer feedback 1`] = `
 
 exports[`AnswersTable renders instructions 1`] = `
 <div
+  aria-label="Answer choices"
   className="answers-table"
+  role="radiogroup"
 >
   <b>
     Instructions
@@ -502,6 +508,7 @@ exports[`AnswersTable renders instructions 1`] = `
       className="answers-answer disabled"
     >
       <input
+        aria-checked={false}
         checked={false}
         className="answer-input-box"
         disabled={true}
@@ -515,18 +522,11 @@ exports[`AnswersTable renders instructions 1`] = `
         htmlFor="1-option-0"
       >
         <span
+          aria-label="Choice A:"
           className="answer-letter-wrapper"
-        >
-          <button
-            aria-label="Choice A:"
-            className="answer-letter"
-            data-test-id="answer-choice-A"
-            disabled={true}
-            onClick={[Function]}
-          >
-            A
-          </button>
-        </span>
+          data-answer-choice="A"
+          data-test-id="answer-choice-A"
+        />
         <div
           className="answer-answer"
         >
@@ -549,6 +549,7 @@ exports[`AnswersTable renders instructions 1`] = `
       className="answers-answer disabled"
     >
       <input
+        aria-checked={false}
         checked={false}
         className="answer-input-box"
         disabled={true}
@@ -562,18 +563,11 @@ exports[`AnswersTable renders instructions 1`] = `
         htmlFor="1-option-1"
       >
         <span
+          aria-label="Choice B:"
           className="answer-letter-wrapper"
-        >
-          <button
-            aria-label="Choice B:"
-            className="answer-letter"
-            data-test-id="answer-choice-B"
-            disabled={true}
-            onClick={[Function]}
-          >
-            B
-          </button>
-        </span>
+          data-answer-choice="B"
+          data-test-id="answer-choice-B"
+        />
         <div
           className="answer-answer"
         >
@@ -594,7 +588,9 @@ exports[`AnswersTable renders instructions 1`] = `
 
 exports[`AnswersTable sorts by given ID order 1`] = `
 <div
+  aria-label="Answer choices"
   className="answers-table"
+  role="radiogroup"
 >
   <div
     className="openstax-answer"
@@ -603,6 +599,7 @@ exports[`AnswersTable sorts by given ID order 1`] = `
       className="answers-answer disabled"
     >
       <input
+        aria-checked={false}
         checked={false}
         className="answer-input-box"
         disabled={true}
@@ -616,18 +613,11 @@ exports[`AnswersTable sorts by given ID order 1`] = `
         htmlFor="1-option-0"
       >
         <span
+          aria-label="Choice A:"
           className="answer-letter-wrapper"
-        >
-          <button
-            aria-label="Choice A:"
-            className="answer-letter"
-            data-test-id="answer-choice-A"
-            disabled={true}
-            onClick={[Function]}
-          >
-            A
-          </button>
-        </span>
+          data-answer-choice="A"
+          data-test-id="answer-choice-A"
+        />
         <div
           className="answer-answer"
         >
@@ -650,6 +640,7 @@ exports[`AnswersTable sorts by given ID order 1`] = `
       className="answers-answer disabled"
     >
       <input
+        aria-checked={false}
         checked={false}
         className="answer-input-box"
         disabled={true}
@@ -663,18 +654,11 @@ exports[`AnswersTable sorts by given ID order 1`] = `
         htmlFor="1-option-1"
       >
         <span
+          aria-label="Choice B:"
           className="answer-letter-wrapper"
-        >
-          <button
-            aria-label="Choice B:"
-            className="answer-letter"
-            data-test-id="answer-choice-B"
-            disabled={true}
-            onClick={[Function]}
-          >
-            B
-          </button>
-        </span>
+          data-answer-choice="B"
+          data-test-id="answer-choice-B"
+        />
         <div
           className="answer-answer"
         >

--- a/src/components/__snapshots__/Exercise.spec.tsx.snap
+++ b/src/components/__snapshots__/Exercise.spec.tsx.snap
@@ -65,12 +65,14 @@ exports[`Exercise using step data matches snapshot 1`] = `
             data-test-id="student-exercise-question"
           >
             <div
-              className="sc-gKXOVf kUGNPP openstax-question step-card-body"
+              className="sc-gKXOVf MMKoc openstax-question step-card-body"
               data-question-number={1}
               data-test-id="question"
             >
               <div
+                aria-label="Answer choices"
                 className="answers-table"
+                role="radiogroup"
               >
                 <div
                   className="openstax-answer"
@@ -79,6 +81,7 @@ exports[`Exercise using step data matches snapshot 1`] = `
                     className="answers-answer disabled answer-selected"
                   >
                     <input
+                      aria-checked={true}
                       checked={true}
                       className="answer-input-box"
                       disabled={true}
@@ -92,18 +95,11 @@ exports[`Exercise using step data matches snapshot 1`] = `
                       htmlFor="1234@5-option-0"
                     >
                       <span
+                        aria-label="Selected Choice A:"
                         className="answer-letter-wrapper"
-                      >
-                        <button
-                          aria-label="Selected Choice A:"
-                          className="answer-letter"
-                          data-test-id="answer-choice-A"
-                          disabled={true}
-                          onClick={[Function]}
-                        >
-                          A
-                        </button>
-                      </span>
+                        data-answer-choice="A"
+                        data-test-id="answer-choice-A"
+                      />
                       <div
                         className="answer-answer"
                       >
@@ -126,6 +122,7 @@ exports[`Exercise using step data matches snapshot 1`] = `
                     className="answers-answer disabled"
                   >
                     <input
+                      aria-checked={false}
                       checked={false}
                       className="answer-input-box"
                       disabled={true}
@@ -139,18 +136,11 @@ exports[`Exercise using step data matches snapshot 1`] = `
                       htmlFor="1234@5-option-1"
                     >
                       <span
+                        aria-label="Choice B:"
                         className="answer-letter-wrapper"
-                      >
-                        <button
-                          aria-label="Choice B:"
-                          className="answer-letter"
-                          data-test-id="answer-choice-B"
-                          disabled={true}
-                          onClick={[Function]}
-                        >
-                          B
-                        </button>
-                      </span>
+                        data-answer-choice="B"
+                        data-test-id="answer-choice-B"
+                      />
                       <div
                         className="answer-answer"
                       >
@@ -262,12 +252,14 @@ exports[`Exercise with question state data matches snapshot 1`] = `
             data-test-id="student-exercise-question"
           >
             <div
-              className="sc-gKXOVf kUGNPP openstax-question step-card-body"
+              className="sc-gKXOVf MMKoc openstax-question step-card-body"
               data-question-number={1}
               data-test-id="question"
             >
               <div
+                aria-label="Answer choices"
                 className="answers-table"
+                role="radiogroup"
               >
                 <div
                   className="openstax-answer"
@@ -276,6 +268,7 @@ exports[`Exercise with question state data matches snapshot 1`] = `
                     className="answers-answer disabled answer-selected"
                   >
                     <input
+                      aria-checked={true}
                       checked={true}
                       className="answer-input-box"
                       disabled={true}
@@ -289,18 +282,11 @@ exports[`Exercise with question state data matches snapshot 1`] = `
                       htmlFor="1-option-0"
                     >
                       <span
+                        aria-label="Selected Choice A:"
                         className="answer-letter-wrapper"
-                      >
-                        <button
-                          aria-label="Selected Choice A:"
-                          className="answer-letter"
-                          data-test-id="answer-choice-A"
-                          disabled={true}
-                          onClick={[Function]}
-                        >
-                          A
-                        </button>
-                      </span>
+                        data-answer-choice="A"
+                        data-test-id="answer-choice-A"
+                      />
                       <div
                         className="answer-answer"
                       >
@@ -323,6 +309,7 @@ exports[`Exercise with question state data matches snapshot 1`] = `
                     className="answers-answer disabled"
                   >
                     <input
+                      aria-checked={false}
                       checked={false}
                       className="answer-input-box"
                       disabled={true}
@@ -336,18 +323,11 @@ exports[`Exercise with question state data matches snapshot 1`] = `
                       htmlFor="1-option-1"
                     >
                       <span
+                        aria-label="Choice B:"
                         className="answer-letter-wrapper"
-                      >
-                        <button
-                          aria-label="Choice B:"
-                          className="answer-letter"
-                          data-test-id="answer-choice-B"
-                          disabled={true}
-                          onClick={[Function]}
-                        >
-                          B
-                        </button>
-                      </span>
+                        data-answer-choice="B"
+                        data-test-id="answer-choice-B"
+                      />
                       <div
                         className="answer-answer"
                       >
@@ -599,12 +579,14 @@ exports[`Exercise with question state data renders header icons with multiple ch
             data-test-id="student-exercise-question"
           >
             <div
-              className="sc-gKXOVf kUGNPP openstax-question step-card-body"
+              className="sc-gKXOVf MMKoc openstax-question step-card-body"
               data-question-number={1}
               data-test-id="question"
             >
               <div
+                aria-label="Answer choices"
                 className="answers-table"
+                role="radiogroup"
               >
                 <div
                   className="openstax-answer"
@@ -613,6 +595,7 @@ exports[`Exercise with question state data renders header icons with multiple ch
                     className="answers-answer disabled answer-selected"
                   >
                     <input
+                      aria-checked={true}
                       checked={true}
                       className="answer-input-box"
                       disabled={true}
@@ -626,18 +609,11 @@ exports[`Exercise with question state data renders header icons with multiple ch
                       htmlFor="1-option-0"
                     >
                       <span
+                        aria-label="Selected Choice A:"
                         className="answer-letter-wrapper"
-                      >
-                        <button
-                          aria-label="Selected Choice A:"
-                          className="answer-letter"
-                          data-test-id="answer-choice-A"
-                          disabled={true}
-                          onClick={[Function]}
-                        >
-                          A
-                        </button>
-                      </span>
+                        data-answer-choice="A"
+                        data-test-id="answer-choice-A"
+                      />
                       <div
                         className="answer-answer"
                       >
@@ -660,6 +636,7 @@ exports[`Exercise with question state data renders header icons with multiple ch
                     className="answers-answer disabled"
                   >
                     <input
+                      aria-checked={false}
                       checked={false}
                       className="answer-input-box"
                       disabled={true}
@@ -673,18 +650,11 @@ exports[`Exercise with question state data renders header icons with multiple ch
                       htmlFor="1-option-1"
                     >
                       <span
+                        aria-label="Choice B:"
                         className="answer-letter-wrapper"
-                      >
-                        <button
-                          aria-label="Choice B:"
-                          className="answer-letter"
-                          data-test-id="answer-choice-B"
-                          disabled={true}
-                          onClick={[Function]}
-                        >
-                          B
-                        </button>
-                      </span>
+                        data-answer-choice="B"
+                        data-test-id="answer-choice-B"
+                      />
                       <div
                         className="answer-answer"
                       >
@@ -976,12 +946,14 @@ exports[`Exercise with question state data renders header icons with two-step ex
             data-test-id="student-exercise-question"
           >
             <div
-              className="sc-gKXOVf kUGNPP openstax-question step-card-body"
+              className="sc-gKXOVf MMKoc openstax-question step-card-body"
               data-question-number={1}
               data-test-id="question"
             >
               <div
+                aria-label="Answer choices"
                 className="answers-table"
+                role="radiogroup"
               >
                 <div
                   className="openstax-answer"
@@ -990,6 +962,7 @@ exports[`Exercise with question state data renders header icons with two-step ex
                     className="answers-answer disabled answer-selected"
                   >
                     <input
+                      aria-checked={true}
                       checked={true}
                       className="answer-input-box"
                       disabled={true}
@@ -1003,18 +976,11 @@ exports[`Exercise with question state data renders header icons with two-step ex
                       htmlFor="1-option-0"
                     >
                       <span
+                        aria-label="Selected Choice A:"
                         className="answer-letter-wrapper"
-                      >
-                        <button
-                          aria-label="Selected Choice A:"
-                          className="answer-letter"
-                          data-test-id="answer-choice-A"
-                          disabled={true}
-                          onClick={[Function]}
-                        >
-                          A
-                        </button>
-                      </span>
+                        data-answer-choice="A"
+                        data-test-id="answer-choice-A"
+                      />
                       <div
                         className="answer-answer"
                       >
@@ -1037,6 +1003,7 @@ exports[`Exercise with question state data renders header icons with two-step ex
                     className="answers-answer disabled"
                   >
                     <input
+                      aria-checked={false}
                       checked={false}
                       className="answer-input-box"
                       disabled={true}
@@ -1050,18 +1017,11 @@ exports[`Exercise with question state data renders header icons with two-step ex
                       htmlFor="1-option-1"
                     >
                       <span
+                        aria-label="Choice B:"
                         className="answer-letter-wrapper"
-                      >
-                        <button
-                          aria-label="Choice B:"
-                          className="answer-letter"
-                          data-test-id="answer-choice-B"
-                          disabled={true}
-                          onClick={[Function]}
-                        >
-                          B
-                        </button>
-                      </span>
+                        data-answer-choice="B"
+                        data-test-id="answer-choice-B"
+                      />
                       <div
                         className="answer-answer"
                       >
@@ -1173,12 +1133,14 @@ exports[`Exercise with question state data shows a detailed solution 1`] = `
             data-test-id="student-exercise-question"
           >
             <div
-              className="sc-gKXOVf kUGNPP openstax-question step-card-body"
+              className="sc-gKXOVf MMKoc openstax-question step-card-body"
               data-question-number={1}
               data-test-id="question"
             >
               <div
+                aria-label="Answer choices"
                 className="answers-table"
+                role="radiogroup"
               >
                 <div
                   className="openstax-answer"
@@ -1187,6 +1149,7 @@ exports[`Exercise with question state data shows a detailed solution 1`] = `
                     className="answers-answer disabled answer-selected"
                   >
                     <input
+                      aria-checked={true}
                       checked={true}
                       className="answer-input-box"
                       disabled={true}
@@ -1200,18 +1163,11 @@ exports[`Exercise with question state data shows a detailed solution 1`] = `
                       htmlFor="1-option-0"
                     >
                       <span
+                        aria-label="Selected Choice A:"
                         className="answer-letter-wrapper"
-                      >
-                        <button
-                          aria-label="Selected Choice A:"
-                          className="answer-letter"
-                          data-test-id="answer-choice-A"
-                          disabled={true}
-                          onClick={[Function]}
-                        >
-                          A
-                        </button>
-                      </span>
+                        data-answer-choice="A"
+                        data-test-id="answer-choice-A"
+                      />
                       <div
                         className="answer-answer"
                       >
@@ -1234,6 +1190,7 @@ exports[`Exercise with question state data shows a detailed solution 1`] = `
                     className="answers-answer disabled"
                   >
                     <input
+                      aria-checked={false}
                       checked={false}
                       className="answer-input-box"
                       disabled={true}
@@ -1247,18 +1204,11 @@ exports[`Exercise with question state data shows a detailed solution 1`] = `
                       htmlFor="1-option-1"
                     >
                       <span
+                        aria-label="Choice B:"
                         className="answer-letter-wrapper"
-                      >
-                        <button
-                          aria-label="Choice B:"
-                          className="answer-letter"
-                          data-test-id="answer-choice-B"
-                          disabled={true}
-                          onClick={[Function]}
-                        >
-                          B
-                        </button>
-                      </span>
+                        data-answer-choice="B"
+                        data-test-id="answer-choice-B"
+                      />
                       <div
                         className="answer-answer"
                       >

--- a/src/components/__snapshots__/ExerciseQuestion.spec.tsx.snap
+++ b/src/components/__snapshots__/ExerciseQuestion.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`ExerciseQuestion matches snapshot 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-dkzDqf cYzaBK openstax-question step-card-body"
+    className="sc-dkzDqf kuDGpR openstax-question step-card-body"
     data-question-number={1}
     data-test-id="question"
   >
@@ -19,7 +19,9 @@ exports[`ExerciseQuestion matches snapshot 1`] = `
       data-question-number={1}
     />
     <div
+      aria-label="Answer choices"
       className="answers-table"
+      role="radiogroup"
     >
       <div
         className="openstax-answer"
@@ -28,6 +30,7 @@ exports[`ExerciseQuestion matches snapshot 1`] = `
           className="answers-answer disabled"
         >
           <input
+            aria-checked={false}
             checked={false}
             className="answer-input-box"
             disabled={true}
@@ -41,18 +44,11 @@ exports[`ExerciseQuestion matches snapshot 1`] = `
             htmlFor="1-option-0"
           >
             <span
+              aria-label="Choice A:"
               className="answer-letter-wrapper"
-            >
-              <button
-                aria-label="Choice A:"
-                className="answer-letter"
-                data-test-id="answer-choice-A"
-                disabled={true}
-                onClick={[Function]}
-              >
-                A
-              </button>
-            </span>
+              data-answer-choice="A"
+              data-test-id="answer-choice-A"
+            />
             <div
               className="answer-answer"
             >
@@ -75,6 +71,7 @@ exports[`ExerciseQuestion matches snapshot 1`] = `
           className="answers-answer disabled"
         >
           <input
+            aria-checked={false}
             checked={false}
             className="answer-input-box"
             disabled={true}
@@ -88,18 +85,11 @@ exports[`ExerciseQuestion matches snapshot 1`] = `
             htmlFor="1-option-1"
           >
             <span
+              aria-label="Choice B:"
               className="answer-letter-wrapper"
-            >
-              <button
-                aria-label="Choice B:"
-                className="answer-letter"
-                data-test-id="answer-choice-B"
-                disabled={true}
-                onClick={[Function]}
-              >
-                B
-              </button>
-            </span>
+              data-answer-choice="B"
+              data-test-id="answer-choice-B"
+            />
             <div
               className="answer-answer"
             >
@@ -157,7 +147,7 @@ exports[`ExerciseQuestion renders Re-submit button 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-dkzDqf cYzaBK openstax-question step-card-body has-incorrect-answer"
+    className="sc-dkzDqf kuDGpR openstax-question step-card-body has-incorrect-answer"
     data-question-number={1}
     data-test-id="question"
   >
@@ -171,7 +161,9 @@ exports[`ExerciseQuestion renders Re-submit button 1`] = `
       data-question-number={1}
     />
     <div
+      aria-label="Answer choices"
       className="answers-table"
+      role="radiogroup"
     >
       <div
         className="openstax-answer"
@@ -180,6 +172,7 @@ exports[`ExerciseQuestion renders Re-submit button 1`] = `
           className="answers-answer answer-selected"
         >
           <input
+            aria-checked={true}
             checked={true}
             className="answer-input-box"
             disabled={false}
@@ -193,18 +186,11 @@ exports[`ExerciseQuestion renders Re-submit button 1`] = `
             htmlFor="1-option-0"
           >
             <span
+              aria-label="Selected Choice A:"
               className="answer-letter-wrapper"
-            >
-              <button
-                aria-label="Selected Choice A:"
-                className="answer-letter"
-                data-test-id="answer-choice-A"
-                disabled={false}
-                onClick={[Function]}
-              >
-                A
-              </button>
-            </span>
+              data-answer-choice="A"
+              data-test-id="answer-choice-A"
+            />
             <div
               className="answer-answer"
             >
@@ -227,6 +213,7 @@ exports[`ExerciseQuestion renders Re-submit button 1`] = `
           className="answers-answer answer-incorrect"
         >
           <input
+            aria-checked={false}
             checked={false}
             className="answer-input-box"
             disabled={false}
@@ -240,18 +227,11 @@ exports[`ExerciseQuestion renders Re-submit button 1`] = `
             htmlFor="1-option-1"
           >
             <span
+              aria-label="Choice B:"
               className="answer-letter-wrapper"
-            >
-              <button
-                aria-label="Choice B:"
-                className="answer-letter"
-                data-test-id="answer-choice-B"
-                disabled={true}
-                onClick={[Function]}
-              >
-                B
-              </button>
-            </span>
+              data-answer-choice="B"
+              data-test-id="answer-choice-B"
+            />
             <div
               className="answer-answer"
             >
@@ -316,7 +296,7 @@ exports[`ExerciseQuestion renders Save button 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-dkzDqf cYzaBK openstax-question step-card-body has-incorrect-answer"
+    className="sc-dkzDqf kuDGpR openstax-question step-card-body has-incorrect-answer"
     data-question-number={1}
     data-test-id="question"
   >
@@ -330,7 +310,9 @@ exports[`ExerciseQuestion renders Save button 1`] = `
       data-question-number={1}
     />
     <div
+      aria-label="Answer choices"
       className="answers-table"
+      role="radiogroup"
     >
       <div
         className="openstax-answer"
@@ -339,6 +321,7 @@ exports[`ExerciseQuestion renders Save button 1`] = `
           className="answers-answer answer-selected"
         >
           <input
+            aria-checked={true}
             checked={true}
             className="answer-input-box"
             disabled={false}
@@ -352,18 +335,11 @@ exports[`ExerciseQuestion renders Save button 1`] = `
             htmlFor="1-option-0"
           >
             <span
+              aria-label="Selected Choice A:"
               className="answer-letter-wrapper"
-            >
-              <button
-                aria-label="Selected Choice A:"
-                className="answer-letter"
-                data-test-id="answer-choice-A"
-                disabled={false}
-                onClick={[Function]}
-              >
-                A
-              </button>
-            </span>
+              data-answer-choice="A"
+              data-test-id="answer-choice-A"
+            />
             <div
               className="answer-answer"
             >
@@ -386,6 +362,7 @@ exports[`ExerciseQuestion renders Save button 1`] = `
           className="answers-answer answer-incorrect"
         >
           <input
+            aria-checked={false}
             checked={false}
             className="answer-input-box"
             disabled={false}
@@ -399,18 +376,11 @@ exports[`ExerciseQuestion renders Save button 1`] = `
             htmlFor="1-option-1"
           >
             <span
+              aria-label="Choice B:"
               className="answer-letter-wrapper"
-            >
-              <button
-                aria-label="Choice B:"
-                className="answer-letter"
-                data-test-id="answer-choice-B"
-                disabled={true}
-                onClick={[Function]}
-              >
-                B
-              </button>
-            </span>
+              data-answer-choice="B"
+              data-test-id="answer-choice-B"
+            />
             <div
               className="answer-answer"
             >
@@ -475,7 +445,7 @@ exports[`ExerciseQuestion renders Submit & continue button 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-dkzDqf cYzaBK openstax-question step-card-body has-incorrect-answer"
+    className="sc-dkzDqf kuDGpR openstax-question step-card-body has-incorrect-answer"
     data-question-number={1}
     data-test-id="question"
   >
@@ -489,7 +459,9 @@ exports[`ExerciseQuestion renders Submit & continue button 1`] = `
       data-question-number={1}
     />
     <div
+      aria-label="Answer choices"
       className="answers-table"
+      role="radiogroup"
     >
       <div
         className="openstax-answer"
@@ -498,6 +470,7 @@ exports[`ExerciseQuestion renders Submit & continue button 1`] = `
           className="answers-answer answer-selected"
         >
           <input
+            aria-checked={true}
             checked={true}
             className="answer-input-box"
             disabled={false}
@@ -511,18 +484,11 @@ exports[`ExerciseQuestion renders Submit & continue button 1`] = `
             htmlFor="1-option-0"
           >
             <span
+              aria-label="Selected Choice A:"
               className="answer-letter-wrapper"
-            >
-              <button
-                aria-label="Selected Choice A:"
-                className="answer-letter"
-                data-test-id="answer-choice-A"
-                disabled={false}
-                onClick={[Function]}
-              >
-                A
-              </button>
-            </span>
+              data-answer-choice="A"
+              data-test-id="answer-choice-A"
+            />
             <div
               className="answer-answer"
             >
@@ -545,6 +511,7 @@ exports[`ExerciseQuestion renders Submit & continue button 1`] = `
           className="answers-answer answer-incorrect"
         >
           <input
+            aria-checked={false}
             checked={false}
             className="answer-input-box"
             disabled={false}
@@ -558,18 +525,11 @@ exports[`ExerciseQuestion renders Submit & continue button 1`] = `
             htmlFor="1-option-1"
           >
             <span
+              aria-label="Choice B:"
               className="answer-letter-wrapper"
-            >
-              <button
-                aria-label="Choice B:"
-                className="answer-letter"
-                data-test-id="answer-choice-B"
-                disabled={true}
-                onClick={[Function]}
-              >
-                B
-              </button>
-            </span>
+              data-answer-choice="B"
+              data-test-id="answer-choice-B"
+            />
             <div
               className="answer-answer"
             >
@@ -634,7 +594,7 @@ exports[`ExerciseQuestion renders all attempts remaining 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-dkzDqf cYzaBK openstax-question step-card-body"
+    className="sc-dkzDqf kuDGpR openstax-question step-card-body"
     data-question-number={1}
     data-test-id="question"
   >
@@ -648,7 +608,9 @@ exports[`ExerciseQuestion renders all attempts remaining 1`] = `
       data-question-number={1}
     />
     <div
+      aria-label="Answer choices"
       className="answers-table"
+      role="radiogroup"
     >
       <div
         className="openstax-answer"
@@ -657,6 +619,7 @@ exports[`ExerciseQuestion renders all attempts remaining 1`] = `
           className="answers-answer"
         >
           <input
+            aria-checked={false}
             checked={false}
             className="answer-input-box"
             disabled={false}
@@ -670,18 +633,11 @@ exports[`ExerciseQuestion renders all attempts remaining 1`] = `
             htmlFor="1-option-0"
           >
             <span
+              aria-label="Choice A:"
               className="answer-letter-wrapper"
-            >
-              <button
-                aria-label="Choice A:"
-                className="answer-letter"
-                data-test-id="answer-choice-A"
-                disabled={false}
-                onClick={[Function]}
-              >
-                A
-              </button>
-            </span>
+              data-answer-choice="A"
+              data-test-id="answer-choice-A"
+            />
             <div
               className="answer-answer"
             >
@@ -704,6 +660,7 @@ exports[`ExerciseQuestion renders all attempts remaining 1`] = `
           className="answers-answer"
         >
           <input
+            aria-checked={false}
             checked={false}
             className="answer-input-box"
             disabled={false}
@@ -717,18 +674,11 @@ exports[`ExerciseQuestion renders all attempts remaining 1`] = `
             htmlFor="1-option-1"
           >
             <span
+              aria-label="Choice B:"
               className="answer-letter-wrapper"
-            >
-              <button
-                aria-label="Choice B:"
-                className="answer-letter"
-                data-test-id="answer-choice-B"
-                disabled={false}
-                onClick={[Function]}
-              >
-                B
-              </button>
-            </span>
+              data-answer-choice="B"
+              data-test-id="answer-choice-B"
+            />
             <div
               className="answer-answer"
             >
@@ -793,7 +743,7 @@ exports[`ExerciseQuestion renders continue button (unused?) 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-dkzDqf cYzaBK openstax-question step-card-body has-incorrect-answer"
+    className="sc-dkzDqf kuDGpR openstax-question step-card-body has-incorrect-answer"
     data-question-number={1}
     data-test-id="question"
   >
@@ -807,7 +757,9 @@ exports[`ExerciseQuestion renders continue button (unused?) 1`] = `
       data-question-number={1}
     />
     <div
+      aria-label="Answer choices"
       className="answers-table"
+      role="radiogroup"
     >
       <div
         className="openstax-answer"
@@ -816,6 +768,7 @@ exports[`ExerciseQuestion renders continue button (unused?) 1`] = `
           className="answers-answer disabled"
         >
           <input
+            aria-checked={false}
             checked={false}
             className="answer-input-box"
             disabled={true}
@@ -829,18 +782,11 @@ exports[`ExerciseQuestion renders continue button (unused?) 1`] = `
             htmlFor="1-option-0"
           >
             <span
+              aria-label="Choice A:"
               className="answer-letter-wrapper"
-            >
-              <button
-                aria-label="Choice A:"
-                className="answer-letter"
-                data-test-id="answer-choice-A"
-                disabled={true}
-                onClick={[Function]}
-              >
-                A
-              </button>
-            </span>
+              data-answer-choice="A"
+              data-test-id="answer-choice-A"
+            />
             <div
               className="answer-answer"
             >
@@ -863,6 +809,7 @@ exports[`ExerciseQuestion renders continue button (unused?) 1`] = `
           className="answers-answer disabled answer-incorrect"
         >
           <input
+            aria-checked={false}
             checked={false}
             className="answer-input-box"
             disabled={true}
@@ -876,18 +823,11 @@ exports[`ExerciseQuestion renders continue button (unused?) 1`] = `
             htmlFor="1-option-1"
           >
             <span
+              aria-label="Choice B:"
               className="answer-letter-wrapper"
-            >
-              <button
-                aria-label="Choice B:"
-                className="answer-letter"
-                data-test-id="answer-choice-B"
-                disabled={true}
-                onClick={[Function]}
-              >
-                B
-              </button>
-            </span>
+              data-answer-choice="B"
+              data-test-id="answer-choice-B"
+            />
             <div
               className="answer-answer"
             >
@@ -951,7 +891,7 @@ exports[`ExerciseQuestion renders detailed solution and published comments 1`] =
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-dkzDqf cYzaBK openstax-question step-card-body has-correct-answer has-incorrect-answer"
+    className="sc-dkzDqf kuDGpR openstax-question step-card-body has-correct-answer has-incorrect-answer"
     data-question-number={1}
     data-test-id="question"
   >
@@ -965,7 +905,9 @@ exports[`ExerciseQuestion renders detailed solution and published comments 1`] =
       data-question-number={1}
     />
     <div
+      aria-label="Answer choices"
       className="answers-table"
+      role="radiogroup"
     >
       <div
         className="openstax-answer"
@@ -973,23 +915,26 @@ exports[`ExerciseQuestion renders detailed solution and published comments 1`] =
         <section
           className="answers-answer disabled answer-correct"
         >
+          <input
+            aria-checked={false}
+            checked={false}
+            className="answer-input-box"
+            disabled={true}
+            id="1-option-0"
+            name="1-options"
+            onChange={[Function]}
+            type="radio"
+          />
           <label
             className="answer-label"
             htmlFor="1-option-0"
           >
             <span
+              aria-label="Choice A:"
               className="answer-letter-wrapper"
-            >
-              <button
-                aria-label="Choice A(Correct Answer):"
-                className="answer-letter"
-                data-test-id="answer-choice-A"
-                disabled={true}
-                onClick={[Function]}
-              >
-                A
-              </button>
-            </span>
+              data-answer-choice="A"
+              data-test-id="answer-choice-A"
+            />
             <div
               className="answer-answer"
             >
@@ -1017,23 +962,26 @@ exports[`ExerciseQuestion renders detailed solution and published comments 1`] =
         <section
           className="answers-answer disabled answer-incorrect"
         >
+          <input
+            aria-checked={false}
+            checked={false}
+            className="answer-input-box"
+            disabled={true}
+            id="1-option-1"
+            name="1-options"
+            onChange={[Function]}
+            type="radio"
+          />
           <label
             className="answer-label"
             htmlFor="1-option-1"
           >
             <span
+              aria-label="Choice B:"
               className="answer-letter-wrapper"
-            >
-              <button
-                aria-label="Choice B(Incorrect Answer):"
-                className="answer-letter"
-                data-test-id="answer-choice-B"
-                disabled={true}
-                onClick={[Function]}
-              >
-                B
-              </button>
-            </span>
+              data-answer-choice="B"
+              data-test-id="answer-choice-B"
+            />
             <div
               className="answer-answer"
             >
@@ -1116,7 +1064,7 @@ exports[`ExerciseQuestion renders free response 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-dkzDqf cYzaBK openstax-question step-card-body"
+    className="sc-dkzDqf kuDGpR openstax-question step-card-body"
     data-question-number={1}
     data-test-id="question"
   >
@@ -1135,7 +1083,9 @@ exports[`ExerciseQuestion renders free response 1`] = `
       A free response
     </div>
     <div
+      aria-label="Answer choices"
       className="answers-table"
+      role="radiogroup"
     >
       <div
         className="openstax-answer"
@@ -1144,6 +1094,7 @@ exports[`ExerciseQuestion renders free response 1`] = `
           className="answers-answer disabled"
         >
           <input
+            aria-checked={false}
             checked={false}
             className="answer-input-box"
             disabled={true}
@@ -1157,18 +1108,11 @@ exports[`ExerciseQuestion renders free response 1`] = `
             htmlFor="1-option-0"
           >
             <span
+              aria-label="Choice A:"
               className="answer-letter-wrapper"
-            >
-              <button
-                aria-label="Choice A:"
-                className="answer-letter"
-                data-test-id="answer-choice-A"
-                disabled={true}
-                onClick={[Function]}
-              >
-                A
-              </button>
-            </span>
+              data-answer-choice="A"
+              data-test-id="answer-choice-A"
+            />
             <div
               className="answer-answer"
             >
@@ -1191,6 +1135,7 @@ exports[`ExerciseQuestion renders free response 1`] = `
           className="answers-answer disabled"
         >
           <input
+            aria-checked={false}
             checked={false}
             className="answer-input-box"
             disabled={true}
@@ -1204,18 +1149,11 @@ exports[`ExerciseQuestion renders free response 1`] = `
             htmlFor="1-option-1"
           >
             <span
+              aria-label="Choice B:"
               className="answer-letter-wrapper"
-            >
-              <button
-                aria-label="Choice B:"
-                className="answer-letter"
-                data-test-id="answer-choice-B"
-                disabled={true}
-                onClick={[Function]}
-              >
-                B
-              </button>
-            </span>
+              data-answer-choice="B"
+              data-test-id="answer-choice-B"
+            />
             <div
               className="answer-answer"
             >
@@ -1273,7 +1211,7 @@ exports[`ExerciseQuestion renders no attempts remaining 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-dkzDqf cYzaBK openstax-question step-card-body has-incorrect-answer"
+    className="sc-dkzDqf kuDGpR openstax-question step-card-body has-incorrect-answer"
     data-question-number={1}
     data-test-id="question"
   >
@@ -1287,7 +1225,9 @@ exports[`ExerciseQuestion renders no attempts remaining 1`] = `
       data-question-number={1}
     />
     <div
+      aria-label="Answer choices"
       className="answers-table"
+      role="radiogroup"
     >
       <div
         className="openstax-answer"
@@ -1296,6 +1236,7 @@ exports[`ExerciseQuestion renders no attempts remaining 1`] = `
           className="answers-answer disabled"
         >
           <input
+            aria-checked={false}
             checked={false}
             className="answer-input-box"
             disabled={true}
@@ -1309,18 +1250,11 @@ exports[`ExerciseQuestion renders no attempts remaining 1`] = `
             htmlFor="1-option-0"
           >
             <span
+              aria-label="Choice A:"
               className="answer-letter-wrapper"
-            >
-              <button
-                aria-label="Choice A:"
-                className="answer-letter"
-                data-test-id="answer-choice-A"
-                disabled={true}
-                onClick={[Function]}
-              >
-                A
-              </button>
-            </span>
+              data-answer-choice="A"
+              data-test-id="answer-choice-A"
+            />
             <div
               className="answer-answer"
             >
@@ -1343,6 +1277,7 @@ exports[`ExerciseQuestion renders no attempts remaining 1`] = `
           className="answers-answer disabled answer-incorrect"
         >
           <input
+            aria-checked={false}
             checked={false}
             className="answer-input-box"
             disabled={true}
@@ -1356,18 +1291,11 @@ exports[`ExerciseQuestion renders no attempts remaining 1`] = `
             htmlFor="1-option-1"
           >
             <span
+              aria-label="Choice B:"
               className="answer-letter-wrapper"
-            >
-              <button
-                aria-label="Choice B:"
-                className="answer-letter"
-                data-test-id="answer-choice-B"
-                disabled={true}
-                onClick={[Function]}
-              >
-                B
-              </button>
-            </span>
+              data-answer-choice="B"
+              data-test-id="answer-choice-B"
+            />
             <div
               className="answer-answer"
             >
@@ -1431,7 +1359,7 @@ exports[`ExerciseQuestion renders some attempts remaining 1`] = `
   data-test-id="student-exercise-question"
 >
   <div
-    className="sc-dkzDqf cYzaBK openstax-question step-card-body has-incorrect-answer"
+    className="sc-dkzDqf kuDGpR openstax-question step-card-body has-incorrect-answer"
     data-question-number={1}
     data-test-id="question"
   >
@@ -1445,7 +1373,9 @@ exports[`ExerciseQuestion renders some attempts remaining 1`] = `
       data-question-number={1}
     />
     <div
+      aria-label="Answer choices"
       className="answers-table"
+      role="radiogroup"
     >
       <div
         className="openstax-answer"
@@ -1454,6 +1384,7 @@ exports[`ExerciseQuestion renders some attempts remaining 1`] = `
           className="answers-answer"
         >
           <input
+            aria-checked={false}
             checked={false}
             className="answer-input-box"
             disabled={false}
@@ -1467,18 +1398,11 @@ exports[`ExerciseQuestion renders some attempts remaining 1`] = `
             htmlFor="1-option-0"
           >
             <span
+              aria-label="Choice A:"
               className="answer-letter-wrapper"
-            >
-              <button
-                aria-label="Choice A:"
-                className="answer-letter"
-                data-test-id="answer-choice-A"
-                disabled={false}
-                onClick={[Function]}
-              >
-                A
-              </button>
-            </span>
+              data-answer-choice="A"
+              data-test-id="answer-choice-A"
+            />
             <div
               className="answer-answer"
             >
@@ -1501,6 +1425,7 @@ exports[`ExerciseQuestion renders some attempts remaining 1`] = `
           className="answers-answer answer-incorrect"
         >
           <input
+            aria-checked={false}
             checked={false}
             className="answer-input-box"
             disabled={false}
@@ -1514,18 +1439,11 @@ exports[`ExerciseQuestion renders some attempts remaining 1`] = `
             htmlFor="1-option-1"
           >
             <span
+              aria-label="Choice B:"
               className="answer-letter-wrapper"
-            >
-              <button
-                aria-label="Choice B:"
-                className="answer-letter"
-                data-test-id="answer-choice-B"
-                disabled={true}
-                onClick={[Function]}
-              >
-                B
-              </button>
-            </span>
+              data-answer-choice="B"
+              data-test-id="answer-choice-B"
+            />
             <div
               className="answer-answer"
             >

--- a/src/components/__snapshots__/Question.spec.tsx.snap
+++ b/src/components/__snapshots__/Question.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Question defaults QuestionHtml html 1`] = `
 <div
-  className="sc-gsnTZi bfsWKR openstax-question"
+  className="sc-gsnTZi bcIUqS openstax-question"
   data-question-number={1}
   data-test-id="question"
 >
@@ -16,7 +16,9 @@ exports[`Question defaults QuestionHtml html 1`] = `
     data-question-number={1}
   />
   <div
+    aria-label="Answer choices"
     className="answers-table"
+    role="radiogroup"
   >
     <div
       className="openstax-answer"
@@ -25,6 +27,7 @@ exports[`Question defaults QuestionHtml html 1`] = `
         className="answers-answer disabled"
       >
         <input
+          aria-checked={false}
           checked={false}
           className="answer-input-box"
           disabled={true}
@@ -38,18 +41,11 @@ exports[`Question defaults QuestionHtml html 1`] = `
           htmlFor="1-option-0"
         >
           <span
+            aria-label="Choice A:"
             className="answer-letter-wrapper"
-          >
-            <button
-              aria-label="Choice A:"
-              className="answer-letter"
-              data-test-id="answer-choice-A"
-              disabled={true}
-              onClick={[Function]}
-            >
-              A
-            </button>
-          </span>
+            data-answer-choice="A"
+            data-test-id="answer-choice-A"
+          />
           <div
             className="answer-answer"
           >
@@ -72,6 +68,7 @@ exports[`Question defaults QuestionHtml html 1`] = `
         className="answers-answer disabled"
       >
         <input
+          aria-checked={false}
           checked={false}
           className="answer-input-box"
           disabled={true}
@@ -85,18 +82,11 @@ exports[`Question defaults QuestionHtml html 1`] = `
           htmlFor="1-option-1"
         >
           <span
+            aria-label="Choice B:"
             className="answer-letter-wrapper"
-          >
-            <button
-              aria-label="Choice B:"
-              className="answer-letter"
-              data-test-id="answer-choice-B"
-              disabled={true}
-              onClick={[Function]}
-            >
-              B
-            </button>
-          </span>
+            data-answer-choice="B"
+            data-test-id="answer-choice-B"
+          />
           <div
             className="answer-answer"
           >
@@ -118,7 +108,7 @@ exports[`Question defaults QuestionHtml html 1`] = `
 
 exports[`Question defaults collaborator_solutions 1`] = `
 <div
-  className="sc-gsnTZi bfsWKR openstax-question"
+  className="sc-gsnTZi bcIUqS openstax-question"
   data-question-number={1}
   data-test-id="question"
 >
@@ -132,7 +122,9 @@ exports[`Question defaults collaborator_solutions 1`] = `
     data-question-number={1}
   />
   <div
+    aria-label="Answer choices"
     className="answers-table"
+    role="radiogroup"
   >
     <div
       className="openstax-answer"
@@ -141,6 +133,7 @@ exports[`Question defaults collaborator_solutions 1`] = `
         className="answers-answer disabled"
       >
         <input
+          aria-checked={false}
           checked={false}
           className="answer-input-box"
           disabled={true}
@@ -154,18 +147,11 @@ exports[`Question defaults collaborator_solutions 1`] = `
           htmlFor="1-option-0"
         >
           <span
+            aria-label="Choice A:"
             className="answer-letter-wrapper"
-          >
-            <button
-              aria-label="Choice A:"
-              className="answer-letter"
-              data-test-id="answer-choice-A"
-              disabled={true}
-              onClick={[Function]}
-            >
-              A
-            </button>
-          </span>
+            data-answer-choice="A"
+            data-test-id="answer-choice-A"
+          />
           <div
             className="answer-answer"
           >
@@ -188,6 +174,7 @@ exports[`Question defaults collaborator_solutions 1`] = `
         className="answers-answer disabled"
       >
         <input
+          aria-checked={false}
           checked={false}
           className="answer-input-box"
           disabled={true}
@@ -201,18 +188,11 @@ exports[`Question defaults collaborator_solutions 1`] = `
           htmlFor="1-option-1"
         >
           <span
+            aria-label="Choice B:"
             className="answer-letter-wrapper"
-          >
-            <button
-              aria-label="Choice B:"
-              className="answer-letter"
-              data-test-id="answer-choice-B"
-              disabled={true}
-              onClick={[Function]}
-            >
-              B
-            </button>
-          </span>
+            data-answer-choice="B"
+            data-test-id="answer-choice-B"
+          />
           <div
             className="answer-answer"
           >
@@ -234,7 +214,7 @@ exports[`Question defaults collaborator_solutions 1`] = `
 
 exports[`Question defaults formats 1`] = `
 <div
-  className="sc-gsnTZi bfsWKR openstax-question"
+  className="sc-gsnTZi bcIUqS openstax-question"
   data-question-number={1}
   data-test-id="question"
 >
@@ -248,7 +228,9 @@ exports[`Question defaults formats 1`] = `
     data-question-number={1}
   />
   <div
+    aria-label="Answer choices"
     className="answers-table"
+    role="radiogroup"
   >
     <div
       className="openstax-answer"
@@ -257,6 +239,7 @@ exports[`Question defaults formats 1`] = `
         className="answers-answer disabled"
       >
         <input
+          aria-checked={false}
           checked={false}
           className="answer-input-box"
           disabled={true}
@@ -270,18 +253,11 @@ exports[`Question defaults formats 1`] = `
           htmlFor="1-option-0"
         >
           <span
+            aria-label="Choice A:"
             className="answer-letter-wrapper"
-          >
-            <button
-              aria-label="Choice A:"
-              className="answer-letter"
-              data-test-id="answer-choice-A"
-              disabled={true}
-              onClick={[Function]}
-            >
-              A
-            </button>
-          </span>
+            data-answer-choice="A"
+            data-test-id="answer-choice-A"
+          />
           <div
             className="answer-answer"
           >
@@ -304,6 +280,7 @@ exports[`Question defaults formats 1`] = `
         className="answers-answer disabled"
       >
         <input
+          aria-checked={false}
           checked={false}
           className="answer-input-box"
           disabled={true}
@@ -317,18 +294,11 @@ exports[`Question defaults formats 1`] = `
           htmlFor="1-option-1"
         >
           <span
+            aria-label="Choice B:"
             className="answer-letter-wrapper"
-          >
-            <button
-              aria-label="Choice B:"
-              className="answer-letter"
-              data-test-id="answer-choice-B"
-              disabled={true}
-              onClick={[Function]}
-            >
-              B
-            </button>
-          </span>
+            data-answer-choice="B"
+            data-test-id="answer-choice-B"
+          />
           <div
             className="answer-answer"
           >
@@ -359,7 +329,7 @@ exports[`Question defaults formats 1`] = `
 
 exports[`Question matches snapshot 1`] = `
 <div
-  className="sc-gsnTZi bfsWKR openstax-question"
+  className="sc-gsnTZi bcIUqS openstax-question"
   data-question-number={1}
   data-test-id="question"
 >
@@ -373,7 +343,9 @@ exports[`Question matches snapshot 1`] = `
     data-question-number={1}
   />
   <div
+    aria-label="Answer choices"
     className="answers-table"
+    role="radiogroup"
   >
     <div
       className="openstax-answer"
@@ -382,6 +354,7 @@ exports[`Question matches snapshot 1`] = `
         className="answers-answer disabled"
       >
         <input
+          aria-checked={false}
           checked={false}
           className="answer-input-box"
           disabled={true}
@@ -395,18 +368,11 @@ exports[`Question matches snapshot 1`] = `
           htmlFor="1-option-0"
         >
           <span
+            aria-label="Choice A:"
             className="answer-letter-wrapper"
-          >
-            <button
-              aria-label="Choice A:"
-              className="answer-letter"
-              data-test-id="answer-choice-A"
-              disabled={true}
-              onClick={[Function]}
-            >
-              A
-            </button>
-          </span>
+            data-answer-choice="A"
+            data-test-id="answer-choice-A"
+          />
           <div
             className="answer-answer"
           >
@@ -429,6 +395,7 @@ exports[`Question matches snapshot 1`] = `
         className="answers-answer disabled"
       >
         <input
+          aria-checked={false}
           checked={false}
           className="answer-input-box"
           disabled={true}
@@ -442,18 +409,11 @@ exports[`Question matches snapshot 1`] = `
           htmlFor="1-option-1"
         >
           <span
+            aria-label="Choice B:"
             className="answer-letter-wrapper"
-          >
-            <button
-              aria-label="Choice B:"
-              className="answer-letter"
-              data-test-id="answer-choice-B"
-              disabled={true}
-              onClick={[Function]}
-            >
-              B
-            </button>
-          </span>
+            data-answer-choice="B"
+            data-test-id="answer-choice-B"
+          />
           <div
             className="answer-answer"
           >
@@ -475,7 +435,7 @@ exports[`Question matches snapshot 1`] = `
 
 exports[`Question renders exercise uid 1`] = `
 <div
-  className="sc-gsnTZi bfsWKR openstax-question"
+  className="sc-gsnTZi bcIUqS openstax-question"
   data-question-number={1}
   data-test-id="question"
 >
@@ -489,7 +449,9 @@ exports[`Question renders exercise uid 1`] = `
     data-question-number={1}
   />
   <div
+    aria-label="Answer choices"
     className="answers-table"
+    role="radiogroup"
   >
     <div
       className="openstax-answer"
@@ -498,6 +460,7 @@ exports[`Question renders exercise uid 1`] = `
         className="answers-answer disabled"
       >
         <input
+          aria-checked={false}
           checked={false}
           className="answer-input-box"
           disabled={true}
@@ -511,18 +474,11 @@ exports[`Question renders exercise uid 1`] = `
           htmlFor="1-option-0"
         >
           <span
+            aria-label="Choice A:"
             className="answer-letter-wrapper"
-          >
-            <button
-              aria-label="Choice A:"
-              className="answer-letter"
-              data-test-id="answer-choice-A"
-              disabled={true}
-              onClick={[Function]}
-            >
-              A
-            </button>
-          </span>
+            data-answer-choice="A"
+            data-test-id="answer-choice-A"
+          />
           <div
             className="answer-answer"
           >
@@ -545,6 +501,7 @@ exports[`Question renders exercise uid 1`] = `
         className="answers-answer disabled"
       >
         <input
+          aria-checked={false}
           checked={false}
           className="answer-input-box"
           disabled={true}
@@ -558,18 +515,11 @@ exports[`Question renders exercise uid 1`] = `
           htmlFor="1-option-1"
         >
           <span
+            aria-label="Choice B:"
             className="answer-letter-wrapper"
-          >
-            <button
-              aria-label="Choice B:"
-              className="answer-letter"
-              data-test-id="answer-choice-B"
-              disabled={true}
-              onClick={[Function]}
-            >
-              B
-            </button>
-          </span>
+            data-answer-choice="B"
+            data-test-id="answer-choice-B"
+          />
           <div
             className="answer-answer"
           >
@@ -596,7 +546,7 @@ exports[`Question renders exercise uid 1`] = `
 
 exports[`Question renders formats 1`] = `
 <div
-  className="sc-gsnTZi bfsWKR openstax-question"
+  className="sc-gsnTZi bcIUqS openstax-question"
   data-question-number={1}
   data-test-id="question"
 >
@@ -610,7 +560,9 @@ exports[`Question renders formats 1`] = `
     data-question-number={1}
   />
   <div
+    aria-label="Answer choices"
     className="answers-table"
+    role="radiogroup"
   >
     <div
       className="openstax-answer"
@@ -619,6 +571,7 @@ exports[`Question renders formats 1`] = `
         className="answers-answer disabled"
       >
         <input
+          aria-checked={false}
           checked={false}
           className="answer-input-box"
           disabled={true}
@@ -632,18 +585,11 @@ exports[`Question renders formats 1`] = `
           htmlFor="1-option-0"
         >
           <span
+            aria-label="Choice A:"
             className="answer-letter-wrapper"
-          >
-            <button
-              aria-label="Choice A:"
-              className="answer-letter"
-              data-test-id="answer-choice-A"
-              disabled={true}
-              onClick={[Function]}
-            >
-              A
-            </button>
-          </span>
+            data-answer-choice="A"
+            data-test-id="answer-choice-A"
+          />
           <div
             className="answer-answer"
           >
@@ -666,6 +612,7 @@ exports[`Question renders formats 1`] = `
         className="answers-answer disabled"
       >
         <input
+          aria-checked={false}
           checked={false}
           className="answer-input-box"
           disabled={true}
@@ -679,18 +626,11 @@ exports[`Question renders formats 1`] = `
           htmlFor="1-option-1"
         >
           <span
+            aria-label="Choice B:"
             className="answer-letter-wrapper"
-          >
-            <button
-              aria-label="Choice B:"
-              className="answer-letter"
-              data-test-id="answer-choice-B"
-              disabled={true}
-              onClick={[Function]}
-            >
-              B
-            </button>
-          </span>
+            data-answer-choice="B"
+            data-test-id="answer-choice-B"
+          />
           <div
             className="answer-answer"
           >
@@ -724,7 +664,7 @@ exports[`Question renders formats 1`] = `
 
 exports[`Question renders solutions 1`] = `
 <div
-  className="sc-gsnTZi bfsWKR openstax-question"
+  className="sc-gsnTZi bcIUqS openstax-question"
   data-question-number={1}
   data-test-id="question"
 >
@@ -738,7 +678,9 @@ exports[`Question renders solutions 1`] = `
     data-question-number={1}
   />
   <div
+    aria-label="Answer choices"
     className="answers-table"
+    role="radiogroup"
   >
     <div
       className="openstax-answer"
@@ -747,6 +689,7 @@ exports[`Question renders solutions 1`] = `
         className="answers-answer disabled"
       >
         <input
+          aria-checked={false}
           checked={false}
           className="answer-input-box"
           disabled={true}
@@ -760,18 +703,11 @@ exports[`Question renders solutions 1`] = `
           htmlFor="1-option-0"
         >
           <span
+            aria-label="Choice A:"
             className="answer-letter-wrapper"
-          >
-            <button
-              aria-label="Choice A:"
-              className="answer-letter"
-              data-test-id="answer-choice-A"
-              disabled={true}
-              onClick={[Function]}
-            >
-              A
-            </button>
-          </span>
+            data-answer-choice="A"
+            data-test-id="answer-choice-A"
+          />
           <div
             className="answer-answer"
           >
@@ -794,6 +730,7 @@ exports[`Question renders solutions 1`] = `
         className="answers-answer disabled"
       >
         <input
+          aria-checked={false}
           checked={false}
           className="answer-input-box"
           disabled={true}
@@ -807,18 +744,11 @@ exports[`Question renders solutions 1`] = `
           htmlFor="1-option-1"
         >
           <span
+            aria-label="Choice B:"
             className="answer-letter-wrapper"
-          >
-            <button
-              aria-label="Choice B:"
-              className="answer-letter"
-              data-test-id="answer-choice-B"
-              disabled={true}
-              onClick={[Function]}
-            >
-              B
-            </button>
-          </span>
+            data-answer-choice="B"
+            data-test-id="answer-choice-B"
+          />
           <div
             className="answer-answer"
           >

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -134,10 +134,10 @@ export const transitions = {
 export const mixins = {
   answer: () => css`
     .answer-label {
-      display: flex;
+      display: inline-flex;
     }
     color: ${palette.neutralDarker};
-    .answer-letter {
+    .answer-letter-wrapper::before {
       width: ${layouts.answer.bubbleSize};
       height: ${layouts.answer.bubbleSize};
       min-width: ${layouts.answer.bubbleSize};
@@ -150,12 +150,14 @@ export const mixins = {
       transition: color ${transitions.answer}, border-color ${transitions.answer}, background-color ${transitions.answer};
       background-color: ${colors.palette.white};
       font-family: "Neue Helvetica W01", Helvetica, Arial, sans-serif;
+      box-sizing: border-box;
+      font-weight: normal;
     }
   `,
   answerColor: (
     color: string, invertBubble = false
   ) => css`
-    .answer-letter {
+    .answer-letter-wrapper::before {
       color: ${invertBubble ? '#fff' : color};
       border-color: ${color};
       ${invertBubble ? `background-color: ${color};` : null}


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-419
https://openstax.atlassian.net/browse/CORE-422

Maybe this should be two PRs, but they were very closely related.

I removed the answer correctness from `ariaLabel` because it was being included a second time in the label itself. The screen reader I was using would read this as something like "left brace correct answer right brace correct answer true"

- Use radio buttons instead of push buttons for answer choices.
Many screen readers have shortcuts to cycle between controls of a type. For example, some will cycle between radio buttons with `r` and push buttons with `b`. Radio buttons also allow changing answer choices via the cursor keys without focus leaving the radio group. This also outsources quite a few accessibility requirements to the browser. 

- Add focus outline to custom radio buttons.
For accessibility, focusable elements should have a visually distinct outline when focused.

- Obscure radio buttons in a way that works with screen readers. 
`display: none` causes screen readers to ignore the element.

- Use `aria-details` to tie the feedback html to the answer.
`aria-details` is preferred over `aria-describedby` when the associated element may contain something other than plain text (more details [here](https://w3c.github.io/aria/#aria-details)).

- Add role=radiogroup to answers-table.
Many screen readers have shortcuts to cycle between radio groups. Screen readers also read the label of the radio group when it gains focus.

- Set width/height of answer-input-box to 1px In react-aria-components, radio buttons are placed inside 1x1 spans with overflow hidden. This change is an attempt to copy that without nesting the radio button inside of a span.

## Screenshots

<img width="607" alt="Screenshot 2024-12-05 at 11 21 44 AM" src="https://github.com/user-attachments/assets/31c8ea78-11b3-45dc-91ed-def5ff344704">

No answer selected

<img width="607" alt="Screenshot 2024-12-05 at 11 21 48 AM" src="https://github.com/user-attachments/assets/57de96e5-fb1a-4cd1-a061-b647d9d4176a">

Answer selected by clicking

<img width="607" alt="Screenshot 2024-12-05 at 11 22 01 AM" src="https://github.com/user-attachments/assets/0d69ede0-6b26-4e49-b441-ca24f372442b">

Answer selected with cursor keys (causes radio group to be focused which outlines it with `checked` color)

<img width="607" alt="Screenshot 2024-12-05 at 11 23 57 AM" src="https://github.com/user-attachments/assets/e58ea6c2-2951-4c5a-8425-e300b2718629">

Computed properties for selected answer radio button

<img width="607" alt="Screenshot 2024-12-05 at 11 23 35 AM" src="https://github.com/user-attachments/assets/a68993ce-0d79-400b-82a6-9e30ac73d036">

Accessibility tree for selecting answers

<img width="607" alt="Screenshot 2024-12-05 at 11 22 30 AM" src="https://github.com/user-attachments/assets/f6cb9483-51d3-463d-9b3d-d6fadadd7f96">

Reviewing answers

<img width="607" alt="Screenshot 2024-12-05 at 12 37 50 PM" src="https://github.com/user-attachments/assets/9dbe5602-a5ad-4284-bae8-14b927ac6a4c">

Computed properties for answer review
