### PR TITLE
Core 415 icon for incomplete progress

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openstax/assessment-components",
-  "version": "1.2.1",
+  "version": "1.2.5",
   "license": "MIT",
   "source": "./src/index.ts",
   "types": "./dist/src/index.d.ts",

--- a/src/components/ProgressBar.stories.tsx
+++ b/src/components/ProgressBar.stories.tsx
@@ -1,7 +1,7 @@
 import { ProgressBar, ProgressBarItemVariant, ProgressBarProps } from './ProgressBar';
 
-const variants = new Array(8).fill({variant: null});
-const variantsInProgress: ProgressBarItemVariant[] = ['isIncorrect', 'isCorrect', 'isIncorrect', 'isIncorrect', null, null, null, null, 'isStatus'];
+const variants = new Array(8).fill({variant: 'isIncomplete'});
+const variantsInProgress: ProgressBarItemVariant[] = ['isIncorrect', 'isCorrect', 'isIncorrect', 'isIncorrect', 'isIncomplete', 'isIncomplete', 'isIncomplete', 'isIncomplete', 'isStatus'];
 
 const props: ProgressBarProps<{variant: ProgressBarItemVariant}> = {
   activeIndex: 0,
@@ -9,7 +9,15 @@ const props: ProgressBarProps<{variant: ProgressBarItemVariant}> = {
   steps: variantsInProgress.map((variant) => ({variant})),
 }
 
+const propsNoFeedback: ProgressBarProps<{variant: ProgressBarItemVariant}> = {
+  ...props,
+  steps: variantsInProgress
+    .map(variant => variant === 'isCorrect' || variant === 'isIncorrect' ? null : variant)
+    .map(variant => ({ variant }))
+}
+
 export const Default = () => <ProgressBar {...props} steps={[...variants, {variant: 'isStatus'}]} />;
 export const InProgress = () => <ProgressBar {...props} activeIndex={4} />;
 export const Review = () => <ProgressBar {...props} activeIndex={2} />;
 export const StatusStep = () => <ProgressBar {...props} activeIndex={8} />;
+export const InProgressNoFeedback = () => <ProgressBar {...propsNoFeedback} activeIndex={4} />;

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -4,6 +4,7 @@ import FlagIcon from '../assets/flag';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCheck } from '@fortawesome/free-solid-svg-icons/faCheck';
 import { faXmark } from '@fortawesome/free-solid-svg-icons/faXmark';
+import { faQuestion } from '@fortawesome/free-solid-svg-icons';
 
 const ProgressBarWrapper = styled.nav`
   display: flex;
@@ -92,7 +93,7 @@ const StyledFontAwesomeIcon = styled(FontAwesomeIcon)`
 `;
 
 const ItemIcon = ({ variant }: { variant: ProgressBarItemVariant }) => {
-  if (!variant || variant !== 'isCorrect' && variant !== 'isIncorrect') {
+  if (!variant || variant !== 'isCorrect' && variant !== 'isIncorrect' && variant !== 'isIncomplete') {
     return null;
   }
 
@@ -107,6 +108,11 @@ const ItemIcon = ({ variant }: { variant: ProgressBarItemVariant }) => {
       color: colors.answer.incorrect,
       label: 'Incorrect',
     },
+    isIncomplete: {
+      icon: faQuestion,
+      color: colors.answer.neutral,
+      label: 'Incomplete'
+    }
   }[variant];
 
   return <StyledFontAwesomeIcon
@@ -132,7 +138,7 @@ export interface ProgressBarItemProps<S> {
   goToStep: (index: number, step: S) => void;
 }
 
-export type ProgressBarItemVariant = 'isCorrect' | 'isIncorrect' | 'isStatus' | null;
+export type ProgressBarItemVariant = 'isCorrect' | 'isIncorrect' | 'isStatus' | 'isIncomplete' | null;
 
 export const ProgressBarItem = <S extends {variant: ProgressBarItemVariant}>({index, isActive, step, goToStep}: ProgressBarItemProps<S>) =>
   <StyledItemWrapper>


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-415

[Assessments branch with these changes](https://github.com/openstax/assessments/tree/core-415-question-incomplete-variant) (core-415-question-incomplete-variant)

<img width="575" alt="Screenshot 2025-01-13 at 2 13 12 PM" src="https://github.com/user-attachments/assets/37594e43-e9b7-4a06-9b5b-8edadf63c002" />

## With feedback:
<img width="575" alt="Screenshot 2025-01-13 at 2 13 42 PM" src="https://github.com/user-attachments/assets/2ab2ddbc-b0e7-4a7b-9c05-696e1591025e" />

## Without feedback:
<img width="575" alt="Screenshot 2025-01-13 at 2 38 16 PM" src="https://github.com/user-attachments/assets/08b6ca45-8568-4313-a6d5-625f88215b0d" />
